### PR TITLE
Adding NJets=2 option to files doSkimSlim.c, data_turnon1.c, fill_data_hists_loop_v2d.c, fill_hists_loop_v2d.c, make_qcdmc_input_files1.c and adding binning.h and run_all.C files

### DIFF
--- a/binning.h
+++ b/binning.h
@@ -1,0 +1,125 @@
+#ifndef binning_h
+#define binning_h
+
+//
+//  Organizing principles of binning.
+//
+//    For each dimension
+//      bin index 0 means below bins used in analysis (e.g. HT<500 is HT bin 0).
+//      bin index 1 is the first bin used
+//      This also goes for btagging, so btag bin 1 is nb=0.
+//      In the bin edges arrays, it goes like this
+//        bin_edge_x[0] = 500. ; // low edge of bin 1.
+//        bin_edge_x[1] = 750. ; // high edge of bin 1, low edge of bin 2.
+//        ...
+//
+
+using namespace std ;
+
+
+   float bin_edges_nj[100]  ;
+   float bin_edges_nb[100]  ;
+   float bin_edges_mht[100]  ;
+   float bin_edges_ht[100][100]  ;
+   int   nb_nj ;
+   int   nb_nb ;
+   int   nb_ht[100] ;
+   int   nb_mht ;
+   int   bi_nj ;
+   int   bi_nb ;
+   int   bi_ht ;
+   int   bi_mht ;
+
+   int   nb_htmht ;
+   int   bi_htmht ;
+
+   int   nb_global ;
+   int   bi_global ;
+   int   bi_nbsum_global ;
+
+
+//=====================================================================================================
+
+   void setup_bins() {
+
+      int bi ;
+
+      bi = 0 ;
+
+      bin_edges_nj[bi] = 1.5 ; bi++ ; // *** adding NJets=2 binning
+      bin_edges_nj[bi] = 2.5 ; bi++ ;
+      bin_edges_nj[bi] = 4.5 ; bi++ ;
+      bin_edges_nj[bi] = 6.5 ; bi++ ;
+      bin_edges_nj[bi] = 8.5 ; bi++ ;
+      bin_edges_nj[bi] = 99.5 ;
+      nb_nj = bi ;
+
+      bi = 0 ;
+      bin_edges_nb[bi] = -0.5 ; bi++ ;
+      bin_edges_nb[bi] =  0.5 ; bi++ ;
+      bin_edges_nb[bi] =  1.5 ; bi++ ;
+      bin_edges_nb[bi] =  2.5 ; bi++ ;
+      bin_edges_nb[bi] =  99.5 ;
+      nb_nb = bi ;
+
+      bi = 0 ;
+      bin_edges_mht[bi] =   250. ; bi++ ;
+      bin_edges_mht[bi] =   300. ; bi++ ;
+      bin_edges_mht[bi] =   350. ; bi++ ;
+      bin_edges_mht[bi] =   500. ; bi++ ;
+      bin_edges_mht[bi] =   750. ; bi++ ;
+      bin_edges_mht[bi] = 20000. ;
+      nb_mht = bi ;
+
+      int mbi(1) ;
+      nb_htmht = 0 ;
+      //--- MHT bin 0
+      bi = 0 ;
+      bin_edges_ht[mbi][bi] =   300. ; bi++ ;
+      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
+      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
+      bin_edges_ht[mbi][bi] = 20000. ;
+      nb_ht[mbi] = bi ;
+      nb_htmht += bi ;
+      mbi++ ;
+      //--- MHT bin 1
+      bi = 0 ;
+      bin_edges_ht[mbi][bi] =   300. ; bi++ ;
+      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
+      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
+      bin_edges_ht[mbi][bi] = 20000. ;
+      nb_ht[mbi] = bi ;
+      nb_htmht += bi ;
+      mbi++ ;
+      //--- MHT bin 2
+      bi = 0 ;
+      bin_edges_ht[mbi][bi] =   350. ; bi++ ;
+      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
+      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
+      bin_edges_ht[mbi][bi] = 20000. ;
+      nb_ht[mbi] = bi ;
+      nb_htmht += bi ;
+      mbi++ ;
+      //--- MHT bin 3
+      bi = 0 ;
+      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
+      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
+      bin_edges_ht[mbi][bi] = 20000. ;
+      nb_ht[mbi] = bi ;
+      nb_htmht += bi ;
+      mbi++ ;
+      //--- MHT bin 4
+      bi = 0 ;
+      bin_edges_ht[mbi][bi] =   750. ; bi++ ;
+      bin_edges_ht[mbi][bi] =  1500. ; bi++ ;
+      bin_edges_ht[mbi][bi] = 20000. ;
+      nb_ht[mbi] = bi ;
+      nb_htmht += bi ;
+
+
+
+      nb_global = nb_htmht * nb_nb * nb_nj ;
+
+   } // setup_bins
+
+#endif

--- a/data_turnon1.c
+++ b/data_turnon1.c
@@ -13,21 +13,9 @@
 
    void data_turnon1( bool include_Njets2 = true ) {
 
-      TString Njet_cut;
-      if ( include_Njets2 == true ) Njet_cut = "& NJets >= 2";
-      else                           Njet_cut = "& NJets >= 3";
-
       TChain ch_ht("tree") ;
       TChain ch_met("tree") ;
 
-     //-----------
-      ///////ch_ht.Add("fnal-prod-v7-skims-slimmed/tree_LDP/tree_JetHT_2016B-2.6ifb-slimskim.root") ;
-      ///////ch_met.Add("fnal-prod-v7-skims-slimmed/tree_LDP/tree_MET_2016B-2.6ifb-slimskim.root") ;
-     //-----------
-      ///////ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016B-slimskim.root") ;
-      ///////ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016C-slimskim.root") ;
-      ///////ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016B-slimskim.root") ;
-      ///////ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016C-slimskim.root") ;
      //-----------
       ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016B-slimskim.root") ;
       ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016C-slimskim.root") ;
@@ -37,11 +25,6 @@
       ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016D-slimskim.root") ;
      //-----------
 
-      //int nbin(35) ;
-      //float xl(0.) ;
-      //float xh(700.) ;
-
-      
       int bin_edges_nj[100];
       int bi,nb_nj ;
 
@@ -66,47 +49,47 @@
       for ( int nj = 0; nj < nb_nj; nj++)
       {
 
-      TString nj_str     ; nj_str     .Form("%d",nj+1); 
-      TString nj_cut_low ; nj_cut_low .Form("%d",bin_edges_nj[nj]);
-      TString nj_cut_high; nj_cut_high.Form("%d",bin_edges_nj[nj+1]);
+         TString nj_str         ; nj_str         .Form("%d",nj+1); 
+         TString nj_cut_low_str ; nj_cut_low_str .Form("%d",bin_edges_nj[nj]);
+         TString nj_cut_high_str; nj_cut_high_str.Form("%d",bin_edges_nj[nj+1];
 
-      denom_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_denom", "MHT, Nj"+nj_str+", HT800" ,  nbin, xbins ) ;
-      numer_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_numer", "MHT, Nj"+nj_str+", MET100",  nbin, xbins ) ;
-      h_eff_nj[nj]       = new TH1F( "h_eff_nj"+nj_str, "Eff, Nj"+nj_str, nbin, xbins ) ;
+         denom_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_denom", "MHT, Nj"+nj_str+", HT800" ,  nbin, xbins ) ;
+         numer_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_numer", "MHT, Nj"+nj_str+", MET100",  nbin, xbins ) ;
+         h_eff_nj[nj]       = new TH1F( "h_eff_nj"+nj_str         , "Eff, Nj"+nj_str           , nbin, xbins ) ;
 
-      ch_ht.Draw("MHT>>h_mht_nj"+nj_str+"_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID &&  HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && NJets >= "+ nj_cut_low + " && NJets < " + nj_cut_high) ;
-      ch_met.Draw("MHT>>h_mht_nj"+nj_str+"_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig) && NJets >= "+ nj_cut_low + " && NJets < " + nj_cut_high ) ;
+         ch_ht.Draw("MHT>>h_mht_nj"+nj_str+"_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID &&  HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && NJets >= "+ nj_cut_low_str + " && NJets < " + nj_cut_high_str) ;
+         ch_met.Draw("MHT>>h_mht_nj"+nj_str+"_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig) && NJets >= "+ nj_cut_low_str + " && NJets < " + nj_cut_high_str ) ;
 
-      add_overflow( denom_h_mht_nj[nj] ) ;
-      add_overflow( numer_h_mht_nj[nj] ) ;
+         add_overflow( denom_h_mht_nj[nj] ) ;
+         add_overflow( numer_h_mht_nj[nj] ) ;
 
-      for ( int bi=1; bi<=nbin; bi++ ) {
+         for ( int bi=1; bi<=nbin; bi++ ) {
 
-         float eff_val(0.) ;
-         float eff_err(0.) ;
-         float denom, numer ;
+            float eff_val(0.) ;
+            float eff_err(0.) ;
+            float denom, numer ;
 
-         denom = denom_h_mht_nj[nj] -> GetBinContent( bi ) ;
-         numer = numer_h_mht_nj[nj] -> GetBinContent( bi ) ;
-         if (denom>0) {
-            eff_val = numer/denom ;
-            eff_err = sqrt( eff_val*(1.-eff_val)/denom ) ;
-         }
-         h_eff_nj[nj] -> SetBinContent( bi, eff_val ) ;
-         h_eff_nj[nj] -> SetBinError( bi, eff_err ) ;
+            denom = denom_h_mht_nj[nj] -> GetBinContent( bi ) ;
+            numer = numer_h_mht_nj[nj] -> GetBinContent( bi ) ;
+            if (denom>0) {
+               eff_val = numer/denom ;
+               eff_err = sqrt( eff_val*(1.-eff_val)/denom ) ;
+            }
+            h_eff_nj[nj] -> SetBinContent( bi, eff_val ) ;
+            h_eff_nj[nj] -> SetBinError( bi, eff_err ) ;
 
 
-      } // bi
+         } // bi
+ 
+         gStyle -> SetOptStat(0) ;
 
-      gStyle -> SetOptStat(0) ;
+         h_eff_nj[nj] -> SetMaximum( 1.05 ) ;
+         h_eff_nj[nj] -> SetMinimum( 0.5 ) ;
 
-      h_eff_nj[nj] -> SetMaximum( 1.05 ) ;
-      h_eff_nj[nj] -> SetMinimum( 0.5 ) ;
+         h_eff_nj[nj] -> SetMarkerStyle(20+nj) ;
+         h_eff_nj[nj] -> SetMarkerColor(2+nj) ;
+      }//nj
 
-      h_eff_nj[nj] -> SetMarkerStyle(20+nj) ;
-
-      h_eff_nj[nj] -> SetMarkerColor(2+nj) ;
-}//nj
       h_eff_nj[0] -> Draw() ;
       gPad -> SetGridx(1) ;
       gPad -> SetGridy(1) ;

--- a/data_turnon1.c
+++ b/data_turnon1.c
@@ -4,14 +4,21 @@
 #include "TSystem.h"
 #include <string>
 
-#include "histio.c"
+#ifndef binning_h
+#include "binning.h"
+#endif
 
+#ifndef histio_c
+#include "histio.c"
+#endif
 
    void add_overflow( TH1F* hp ) ;
 
   //---------
 
-   void data_turnon1( bool include_Njets2 = true ) {
+   void data_turnon1(  ) {
+
+      setup_bins();
 
       TChain ch_ht("tree") ;
       TChain ch_met("tree") ;
@@ -25,19 +32,6 @@
       ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016D-slimskim.root") ;
      //-----------
 
-      int bin_edges_nj[100];
-      int bi,nb_nj ;
-
-      bi = 0 ;
-      if ( include_Njets2 == true )
-      {   bin_edges_nj[bi] = 2 ; bi++ ;}
-      bin_edges_nj[bi] = 3 ; bi++ ;
-      bin_edges_nj[bi] = 5 ; bi++ ;
-      bin_edges_nj[bi] = 7 ; bi++ ;
-      bin_edges_nj[bi] = 9 ; bi++ ;
-      bin_edges_nj[bi] = 100 ;
-      nb_nj = bi ;
-
 
       int nbin(10) ;
       double xbins[11] = {0., 200., 220, 240, 260, 280, 300, 340, 400, 500, 700 } ;
@@ -50,8 +44,8 @@
       {
 
          TString nj_str         ; nj_str         .Form("%d",nj+1); 
-         TString nj_cut_low_str ; nj_cut_low_str .Form("%d",bin_edges_nj[nj]);
-         TString nj_cut_high_str; nj_cut_high_str.Form("%d",bin_edges_nj[nj+1];
+         TString nj_cut_low_str ; nj_cut_low_str .Form("%f",bin_edges_nj[nj]);
+         TString nj_cut_high_str; nj_cut_high_str.Form("%f",bin_edges_nj[nj+1]);
 
          denom_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_denom", "MHT, Nj"+nj_str+", HT800" ,  nbin, xbins ) ;
          numer_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_numer", "MHT, Nj"+nj_str+", MET100",  nbin, xbins ) ;

--- a/data_turnon1.c
+++ b/data_turnon1.c
@@ -1,3 +1,8 @@
+#include "TChain.h"
+#include "TStyle.h"
+#include "TPad.h"
+#include "TSystem.h"
+#include <string>
 
 #include "histio.c"
 
@@ -6,7 +11,11 @@
 
   //---------
 
-   void data_turnon1() {
+   void data_turnon1( bool include_Njets2 = true ) {
+
+      TString Njet_cut;
+      if ( include_Njets2 == true ) Njet_cut = "& NJets >= 2";
+      else                           Njet_cut = "& NJets >= 3";
 
       TChain ch_ht("tree") ;
       TChain ch_met("tree") ;
@@ -20,60 +29,56 @@
       ///////ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016B-slimskim.root") ;
       ///////ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016C-slimskim.root") ;
      //-----------
-      ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_JetHT_2016B-slimskim.root") ;
-      ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_JetHT_2016C-slimskim.root") ;
-      ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_JetHT_2016D-slimskim.root") ;
-      ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_MET_2016B-slimskim.root") ;
-      ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_MET_2016C-slimskim.root") ;
-      ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_MET_2016D-slimskim.root") ;
+      ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016B-slimskim.root") ;
+      ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016C-slimskim.root") ;
+      ch_ht.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_JetHT_2016D-slimskim.root") ;
+      ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016B-slimskim.root") ;
+      ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016C-slimskim.root") ;
+      ch_met.Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016D-slimskim.root") ;
      //-----------
 
       //int nbin(35) ;
       //float xl(0.) ;
       //float xh(700.) ;
 
+      
+      int bin_edges_nj[100];
+      int bi,nb_nj ;
+
+      bi = 0 ;
+      if ( include_Njets2 == true )
+      {   bin_edges_nj[bi] = 2 ; bi++ ;}
+      bin_edges_nj[bi] = 3 ; bi++ ;
+      bin_edges_nj[bi] = 5 ; bi++ ;
+      bin_edges_nj[bi] = 7 ; bi++ ;
+      bin_edges_nj[bi] = 9 ; bi++ ;
+      bin_edges_nj[bi] = 100 ;
+      nb_nj = bi ;
+
+
       int nbin(10) ;
       double xbins[11] = {0., 200., 220, 240, 260, 280, 300, 340, 400, 500, 700 } ;
 
-      TH1F* h_mht_nj1_denom = new TH1F( "h_mht_nj1_denom", "MHT, Nj1, HT800" ,  nbin, xbins ) ;
-      TH1F* h_mht_nj1_numer = new TH1F( "h_mht_nj1_numer", "MHT, Nj1, MET100",  nbin, xbins ) ;
-      TH1F* h_eff_nj1 = new TH1F( "h_eff_nj1", "Eff, Nj1", nbin, xbins ) ;
+      TH1F* denom_h_mht_nj[10];
+      TH1F* numer_h_mht_nj[10];
+      TH1F* h_eff_nj[10];
 
-      TH1F* h_mht_nj2_denom = new TH1F( "h_mht_nj2_denom", "MHT, nj2, HT800" ,  nbin, xbins ) ;
-      TH1F* h_mht_nj2_numer = new TH1F( "h_mht_nj2_numer", "MHT, nj2, MET100",  nbin, xbins ) ;
-      TH1F* h_eff_nj2 = new TH1F( "h_eff_nj2", "Eff, nj2", nbin, xbins ) ;
+      for ( int nj = 0; nj < nb_nj; nj++)
+      {
 
-      TH1F* h_mht_nj3_denom = new TH1F( "h_mht_nj3_denom", "MHT, nj3, HT800" ,  nbin, xbins ) ;
-      TH1F* h_mht_nj3_numer = new TH1F( "h_mht_nj3_numer", "MHT, nj3, MET100",  nbin, xbins ) ;
-      TH1F* h_eff_nj3 = new TH1F( "h_eff_nj3", "Eff, nj3", nbin, xbins ) ;
+      TString nj_str     ; nj_str     .Form("%d",nj+1); 
+      TString nj_cut_low ; nj_cut_low .Form("%d",bin_edges_nj[nj]);
+      TString nj_cut_high; nj_cut_high.Form("%d",bin_edges_nj[nj+1]);
 
-      TH1F* h_mht_nj4_denom = new TH1F( "h_mht_nj4_denom", "MHT, nj4, HT800" ,  nbin, xbins ) ;
-      TH1F* h_mht_nj4_numer = new TH1F( "h_mht_nj4_numer", "MHT, nj4, MET100",  nbin, xbins ) ;
-      TH1F* h_eff_nj4 = new TH1F( "h_eff_nj4", "Eff, nj4", nbin, xbins ) ;
+      denom_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_denom", "MHT, Nj"+nj_str+", HT800" ,  nbin, xbins ) ;
+      numer_h_mht_nj[nj] = new TH1F( "h_mht_nj"+nj_str+"_numer", "MHT, Nj"+nj_str+", MET100",  nbin, xbins ) ;
+      h_eff_nj[nj]       = new TH1F( "h_eff_nj"+nj_str, "Eff, Nj"+nj_str, nbin, xbins ) ;
 
+      ch_ht.Draw("MHT>>h_mht_nj"+nj_str+"_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID &&  HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && NJets >= "+ nj_cut_low + " && NJets < " + nj_cut_high) ;
+      ch_met.Draw("MHT>>h_mht_nj"+nj_str+"_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig) && NJets >= "+ nj_cut_low + " && NJets < " + nj_cut_high ) ;
 
-      ch_ht.Draw("MHT>>h_mht_nj1_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=3 && NJets<=4 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig" ) ;
-      ch_met.Draw("MHT>>h_mht_nj1_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=3 && NJets<=4 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig)" ) ;
-
-      ch_ht.Draw("MHT>>h_mht_nj2_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=5 && NJets<=6 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig" ) ;
-      ch_met.Draw("MHT>>h_mht_nj2_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=5 && NJets<=6 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig)" ) ;
-
-      ch_ht.Draw("MHT>>h_mht_nj3_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=7 && NJets<=8 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig" ) ;
-      ch_met.Draw("MHT>>h_mht_nj3_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=7 && NJets<=8 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig)" ) ;
-
-      ch_ht.Draw("MHT>>h_mht_nj4_denom","HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=9 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig" ) ;
-      ch_met.Draw("MHT>>h_mht_nj4_numer", "HBHEIsoNoiseFilter == 1 && HBHENoiseFilter == 1 && eeBadScFilter == 1 && EcalDeadCellTriggerPrimitiveFilter == 1 && NVtx > 0 && JetID && NJets>=9 && HT>900 && (MET>100 && CaloMET>80 && MET/CaloMET<5) && pass_ht800_trig && (pass_pfmet100_trig||pass_pfmetnomu100_trig)" ) ;
-
-      add_overflow( h_mht_nj1_denom ) ;
-      add_overflow( h_mht_nj2_denom ) ;
-      add_overflow( h_mht_nj3_denom ) ;
-      add_overflow( h_mht_nj4_denom ) ;
-
-      add_overflow( h_mht_nj1_numer ) ;
-      add_overflow( h_mht_nj2_numer ) ;
-      add_overflow( h_mht_nj3_numer ) ;
-      add_overflow( h_mht_nj4_numer ) ;
-
+      add_overflow( denom_h_mht_nj[nj] ) ;
+      add_overflow( numer_h_mht_nj[nj] ) ;
 
       for ( int bi=1; bi<=nbin; bi++ ) {
 
@@ -81,77 +86,33 @@
          float eff_err(0.) ;
          float denom, numer ;
 
-         denom = h_mht_nj1_denom -> GetBinContent( bi ) ;
-         numer = h_mht_nj1_numer -> GetBinContent( bi ) ;
+         denom = denom_h_mht_nj[nj] -> GetBinContent( bi ) ;
+         numer = numer_h_mht_nj[nj] -> GetBinContent( bi ) ;
          if (denom>0) {
             eff_val = numer/denom ;
             eff_err = sqrt( eff_val*(1.-eff_val)/denom ) ;
          }
-         h_eff_nj1 -> SetBinContent( bi, eff_val ) ;
-         h_eff_nj1 -> SetBinError( bi, eff_err ) ;
+         h_eff_nj[nj] -> SetBinContent( bi, eff_val ) ;
+         h_eff_nj[nj] -> SetBinError( bi, eff_err ) ;
 
-
-         denom = h_mht_nj2_denom -> GetBinContent( bi ) ;
-         numer = h_mht_nj2_numer -> GetBinContent( bi ) ;
-         if (denom>0) {
-            eff_val = numer/denom ;
-            eff_err = sqrt( eff_val*(1.-eff_val)/denom ) ;
-         }
-         h_eff_nj2 -> SetBinContent( bi, eff_val ) ;
-         h_eff_nj2 -> SetBinError( bi, eff_err ) ;
-
-
-         denom = h_mht_nj3_denom -> GetBinContent( bi ) ;
-         numer = h_mht_nj3_numer -> GetBinContent( bi ) ;
-         if (denom>0) {
-            eff_val = numer/denom ;
-            eff_err = sqrt( eff_val*(1.-eff_val)/denom ) ;
-         }
-         h_eff_nj3 -> SetBinContent( bi, eff_val ) ;
-         h_eff_nj3 -> SetBinError( bi, eff_err ) ;
-
-
-         denom = h_mht_nj4_denom -> GetBinContent( bi ) ;
-         numer = h_mht_nj4_numer -> GetBinContent( bi ) ;
-         if (denom>0) {
-            eff_val = numer/denom ;
-            eff_err = sqrt( eff_val*(1.-eff_val)/denom ) ;
-         }
-         h_eff_nj4 -> SetBinContent( bi, eff_val ) ;
-         h_eff_nj4 -> SetBinError( bi, eff_err ) ;
 
       } // bi
 
       gStyle -> SetOptStat(0) ;
 
-      h_eff_nj1 -> SetMaximum( 1.05 ) ;
-      h_eff_nj1 -> SetMinimum( 0.5 ) ;
+      h_eff_nj[nj] -> SetMaximum( 1.05 ) ;
+      h_eff_nj[nj] -> SetMinimum( 0.5 ) ;
 
-      h_eff_nj2 -> SetMaximum( 1.05 ) ;
-      h_eff_nj2 -> SetMinimum( 0.5 ) ;
+      h_eff_nj[nj] -> SetMarkerStyle(20+nj) ;
 
-      h_eff_nj3 -> SetMaximum( 1.05 ) ;
-      h_eff_nj3 -> SetMinimum( 0.5 ) ;
-
-      h_eff_nj4 -> SetMaximum( 1.05 ) ;
-      h_eff_nj4 -> SetMinimum( 0.5 ) ;
-
-
-      h_eff_nj1 -> SetMarkerStyle(20) ;
-      h_eff_nj2 -> SetMarkerStyle(21) ;
-      h_eff_nj3 -> SetMarkerStyle(22) ;
-      h_eff_nj4 -> SetMarkerStyle(23) ;
-
-      h_eff_nj2 -> SetMarkerColor(2) ;
-      h_eff_nj3 -> SetMarkerColor(3) ;
-      h_eff_nj4 -> SetMarkerColor(4) ;
-
-      h_eff_nj1 -> Draw() ;
+      h_eff_nj[nj] -> SetMarkerColor(2+nj) ;
+}//nj
+      h_eff_nj[0] -> Draw() ;
       gPad -> SetGridx(1) ;
       gPad -> SetGridy(1) ;
-      h_eff_nj2 -> Draw("same") ;
-      h_eff_nj3 -> Draw("same") ;
-      h_eff_nj4 -> Draw("same") ;
+      h_eff_nj[1] -> Draw("same") ;
+      h_eff_nj[2] -> Draw("same") ;
+      h_eff_nj[3] -> Draw("same") ;
 
 
       gSystem -> Exec( "mkdir -p outputfiles" ) ;

--- a/data_turnon1.c
+++ b/data_turnon1.c
@@ -6,14 +6,8 @@
 #include "TPad.h"
 #include "TSystem.h"
 #include <string>
-
-#ifndef binning_h
 #include "binning.h"
-#endif
-
-#ifndef histio_c
 #include "histio.c"
-#endif
 
    void add_overflow( TH1F* hp ) ;
 

--- a/data_turnon1.c
+++ b/data_turnon1.c
@@ -1,3 +1,6 @@
+#ifndef data_turnon1_c
+#define data_turnon1_c
+
 #include "TChain.h"
 #include "TStyle.h"
 #include "TPad.h"
@@ -114,4 +117,4 @@
 
  //=========================================================
 
-
+#endif

--- a/fill_data_hists_loop_v2d.c
+++ b/fill_data_hists_loop_v2d.c
@@ -1,3 +1,6 @@
+#ifndef fill_data_hists_loop_v2d_c
+#define fill_data_hists_loop_v2d_c
+
 
 //
 //  Organizing principles of binning.
@@ -28,6 +31,9 @@
 #include "histio.c"
 #include <iostream>
 #include <vector>
+
+#include "binning.h"
+
 using namespace std ;
 
 
@@ -43,19 +49,28 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
 
    if (fChain == 0) return;
 
+   TH1F * h_hdp_nb[10], *h_ldp_nb[10];
+
+      for ( int nb = 0; nb < nb_nb; nb++)
+      {
+
+         TString nb_str         ; nb_str         .Form("%d",nb);
+
+         h_hdp_nb[nb] = new TH1F( "h_hdp_nb"+nb_str, "HDP events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_hdp_nb[nb] -> Sumw2() ;
+         set_bin_labels( h_hdp_nb[nb] ) ;
+
+         h_ldp_nb[nb] = new TH1F( "h_ldp_nb"+nb_str, "ldp events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_ldp_nb[nb] -> Sumw2() ;
+         set_bin_labels( h_ldp_nb[nb] ) ;
+
+
+      }
+
+
 
    TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ; h_hdp -> Sumw2() ;
    set_bin_labels_div_by_nb( h_hdp ) ;
    TH1F* h_nbsum_hdp = new TH1F( "h_nbsum_hdp", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nbsum_hdp -> Sumw2() ;
    set_bin_labels( h_nbsum_hdp ) ;
-   TH1F* h_nb0_hdp = new TH1F( "h_nb0_hdp", "HDP events, Nb=0", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb0_hdp -> Sumw2() ;
-   set_bin_labels( h_nb0_hdp ) ;
-   TH1F* h_nb1_hdp = new TH1F( "h_nb1_hdp", "HDP events, Nb=1", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb1_hdp -> Sumw2() ;
-   set_bin_labels( h_nb1_hdp ) ;
-   TH1F* h_nb2_hdp = new TH1F( "h_nb2_hdp", "HDP events, Nb=2", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb2_hdp -> Sumw2() ;
-   set_bin_labels( h_nb2_hdp ) ;
-   TH1F* h_nb3_hdp = new TH1F( "h_nb3_hdp", "HDP events, Nb=3", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb3_hdp -> Sumw2() ;
-   set_bin_labels( h_nb3_hdp ) ;
    TH1F* h_mhtc_hdp = new TH1F( "h_mhtc_hdp", "HDP events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ; h_mhtc_hdp -> Sumw2() ;
    set_bin_labels_mhtc_plot( h_mhtc_hdp ) ;
 
@@ -63,14 +78,6 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
    set_bin_labels_div_by_nb( h_ldp ) ;
    TH1F* h_nbsum_ldp = new TH1F( "h_nbsum_ldp", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nbsum_ldp -> Sumw2() ;
    set_bin_labels( h_nbsum_ldp ) ;
-   TH1F* h_nb0_ldp = new TH1F( "h_nb0_ldp", "ldp events, Nb=0", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb0_ldp -> Sumw2() ;
-   set_bin_labels( h_nb0_ldp ) ;
-   TH1F* h_nb1_ldp = new TH1F( "h_nb1_ldp", "ldp events, Nb=1", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb1_ldp -> Sumw2() ;
-   set_bin_labels( h_nb1_ldp ) ;
-   TH1F* h_nb2_ldp = new TH1F( "h_nb2_ldp", "ldp events, Nb=2", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb2_ldp -> Sumw2() ;
-   set_bin_labels( h_nb2_ldp ) ;
-   TH1F* h_nb3_ldp = new TH1F( "h_nb3_ldp", "ldp events, Nb=3", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nb3_ldp -> Sumw2() ;
-   set_bin_labels( h_nb3_ldp ) ;
    TH1F* h_mhtc_ldp = new TH1F( "h_mhtc_ldp", "ldp events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ; h_mhtc_ldp -> Sumw2() ;
    set_bin_labels_mhtc_plot( h_mhtc_ldp ) ;
 
@@ -221,9 +228,9 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
       if ( isjunk ) continue ;
 
     //-- new baseline
-      if ( NJets < 3 ) continue ;
-      if ( MHT < 250 ) continue ;
-      if ( HT < 300 ) continue ;
+      if ( NJets < bin_edges_nj[0] ) continue ;
+      if ( MHT < bin_edges_mht[0] ) continue ;
+      if ( HT < bin_edges_ht[1][0] ) continue ;
 
 
       h_mht -> Fill( MHT, hw ) ;
@@ -259,19 +266,19 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
             h_hdp -> Fill( bi_global, hw ) ;
             //if ( bi_global == 30 ) fprintf( ofp, "%20u %20u %20lld\n", RunNum, LumiBlockNum, EvtNum ) ;
             h_nbsum_hdp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags == 0 ) h_nb0_hdp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags == 1 ) h_nb1_hdp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags == 2 ) h_nb2_hdp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags >= 3 ) h_nb3_hdp -> Fill( bi_nbsum_global, hw ) ;
+
+            for ( int nb = 0; nb < nb_nb; nb++)
+               if ( BTags > bin_edges_nb[nb] && BTags < bin_edges_nb[nb+1] ) h_hdp_nb[nb] -> Fill( bi_nbsum_global, hw ) ;
+
          }
          if ( bi_mht == 1 ) h_mhtc_hdp -> Fill( bi_mhtc_plot , hw ) ;
       } else {
             h_ldp -> Fill( bi_global, hw ) ;
             h_nbsum_ldp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags == 0 ) h_nb0_ldp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags == 1 ) h_nb1_ldp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags == 2 ) h_nb2_ldp -> Fill( bi_nbsum_global, hw ) ;
-            if ( BTags >= 3 ) h_nb3_ldp -> Fill( bi_nbsum_global, hw ) ;
+
+            for ( int nb = 0; nb < nb_nb; nb++)
+               if ( BTags > bin_edges_nb[nb] && BTags < bin_edges_nb[nb+1] ) h_ldp_nb[nb] -> Fill( bi_nbsum_global, hw ) ;
+
          if ( bi_mht == 1 ) h_mhtc_ldp -> Fill( bi_mhtc_plot , hw ) ;
       }
 
@@ -307,131 +314,6 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
 
 } // Loop
 
-//=====================================================================================================
-
-   void fill_data_hists_loop_v2d::setup_bins() {
-
-      int bi ;
-
-      bi = 0 ;
-      bin_edges_nj[bi] = 2.5 ; bi++ ;
-      bin_edges_nj[bi] = 4.5 ; bi++ ;
-      bin_edges_nj[bi] = 6.5 ; bi++ ;
-      bin_edges_nj[bi] = 8.5 ; bi++ ;
-      bin_edges_nj[bi] = 99.5 ;
-      nb_nj = bi ;
-
-      bi = 0 ;
-      bin_edges_nb[bi] = -0.5 ; bi++ ;
-      bin_edges_nb[bi] =  0.5 ; bi++ ;
-      bin_edges_nb[bi] =  1.5 ; bi++ ;
-      bin_edges_nb[bi] =  2.5 ; bi++ ;
-      bin_edges_nb[bi] =  99.5 ;
-      nb_nb = bi ;
-
-      bi = 0 ;
-      bin_edges_mht[bi] =   250. ; bi++ ;
-      bin_edges_mht[bi] =   300. ; bi++ ;
-      bin_edges_mht[bi] =   350. ; bi++ ;
-      bin_edges_mht[bi] =   500. ; bi++ ;
-      bin_edges_mht[bi] =   750. ; bi++ ;
-      bin_edges_mht[bi] = 20000. ;
-      nb_mht = bi ;
-
-      int mbi(1) ;
-      nb_htmht = 0 ;
-      //--- MHT bin 0
-      bi = 0 ;
-      bin_edges_ht[mbi][bi] =   300. ; bi++ ;
-      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
-      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
-      bin_edges_ht[mbi][bi] = 20000. ;
-      nb_ht[mbi] = bi ;
-      nb_htmht += bi ;
-      mbi++ ;
-      //--- MHT bin 1
-      bi = 0 ;
-      bin_edges_ht[mbi][bi] =   300. ; bi++ ;
-      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
-      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
-      bin_edges_ht[mbi][bi] = 20000. ;
-      nb_ht[mbi] = bi ;
-      nb_htmht += bi ;
-      mbi++ ;
-      //--- MHT bin 2
-      bi = 0 ;
-      bin_edges_ht[mbi][bi] =   350. ; bi++ ;
-      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
-      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
-      bin_edges_ht[mbi][bi] = 20000. ;
-      nb_ht[mbi] = bi ;
-      nb_htmht += bi ;
-      mbi++ ;
-      //--- MHT bin 3
-      bi = 0 ;
-      bin_edges_ht[mbi][bi] =   500. ; bi++ ;
-      bin_edges_ht[mbi][bi] =  1000. ; bi++ ;
-      bin_edges_ht[mbi][bi] = 20000. ;
-      nb_ht[mbi] = bi ;
-      nb_htmht += bi ;
-      mbi++ ;
-      //--- MHT bin 4
-      bi = 0 ;
-      bin_edges_ht[mbi][bi] =   750. ; bi++ ;
-      bin_edges_ht[mbi][bi] =  1500. ; bi++ ;
-      bin_edges_ht[mbi][bi] = 20000. ;
-      nb_ht[mbi] = bi ;
-      nb_htmht += bi ;
-
-
-
-      nb_global = nb_htmht * nb_nb * nb_nj ;
-
-      printf("\n\n") ;
-      printf("  nj bins : %d\n", nb_nj ) ; for ( int i=1; i<=nb_nj; i++ ) { printf("    nj bin %2d : [%.1f,%.1f]\n", i, bin_edges_nj[i-1], bin_edges_nj[i] ) ; }
-      printf("  nb bins : %d\n", nb_nb ) ; for ( int i=1; i<=nb_nb; i++ ) { printf("    nb bin %2d : [%.1f,%.1f]\n", i, bin_edges_nb[i-1], bin_edges_nb[i] ) ; }
-      printf("  mht bins : %d\n", nb_mht ) ; for ( int i=1; i<=nb_mht; i++ ) { printf("    mht bin %2d : [%.1f,%.1f]\n", i, bin_edges_mht[i-1], bin_edges_mht[i] ) ; }
-      for ( int mbi=1; mbi<=nb_mht; mbi++ ) {
-         printf("  ht bins, mht%d : %d\n", mbi, nb_ht[mbi] ) ; for ( int i=1; i<=nb_ht[mbi]; i++ ) { printf("    ht bin %2d : [%.1f,%.1f]\n", i, bin_edges_ht[mbi][i-1], bin_edges_ht[mbi][i] ) ; }
-      }
-      printf("\n\n") ;
-
-      TH1F* h_nj_bin_index = new TH1F( "h_nj_bin_index", "Njet bin index", nb_global, 0.5, nb_global+0.5 ) ;
-      TH1F* h_nb_bin_index = new TH1F( "h_nb_bin_index", "Nb bin index", nb_global, 0.5, nb_global+0.5 ) ;
-      TH1F* h_htmht_bin_index = new TH1F( "h_htmht_bin_index", "HTMHT bin index", nb_global, 0.5, nb_global+0.5 ) ;
-      TH1F* h_ht_bin_index = new TH1F( "h_ht_bin_index", "HT bin index", nb_global, 0.5, nb_global+0.5 ) ;
-      TH1F* h_mht_bin_index = new TH1F( "h_mht_bin_index", "MHT bin index", nb_global, 0.5, nb_global+0.5 ) ;
-
-      printf("\n\n") ;
-      for ( int bi=1; bi<=nb_global; bi++ ) {
-         int tbi_nj; int tbi_nb; int tbi_htmht; int tbi_ht; int tbi_mht ;
-         translate_global_bin( bi, tbi_nj, tbi_nb, tbi_htmht, tbi_ht, tbi_mht ) ;
-         h_nj_bin_index -> SetBinContent( bi, tbi_nj ) ;
-         h_nb_bin_index -> SetBinContent( bi, tbi_nb ) ;
-         h_htmht_bin_index -> SetBinContent( bi, tbi_htmht ) ;
-         h_ht_bin_index -> SetBinContent( bi, tbi_ht ) ;
-         h_mht_bin_index -> SetBinContent( bi, tbi_mht ) ;
-      } // bi
-
-
-      TH1F* h_nbsum_nj_bin_index = new TH1F( "h_nbsum_nj_bin_index", "Njet bin index", nb_global/nb_nb, 0.5, nb_global/nb_nb+0.5 ) ;
-      TH1F* h_nbsum_htmht_bin_index = new TH1F( "h_nbsum_htmht_bin_index", "HTMHT bin index", nb_global/nb_nb, 0.5, nb_global/nb_nb+0.5 ) ;
-      TH1F* h_nbsum_ht_bin_index = new TH1F( "h_nbsum_ht_bin_index", "HT bin index", nb_global/nb_nb, 0.5, nb_global/nb_nb+0.5 ) ;
-      TH1F* h_nbsum_mht_bin_index = new TH1F( "h_nbsum_mht_bin_index", "MHT bin index", nb_global/nb_nb, 0.5, nb_global/nb_nb+0.5 ) ;
-
-      printf("\n\n") ;
-      for ( int bi=1; bi<=nb_global/nb_nb; bi++ ) {
-         int tbi_nj; int tbi_htmht; int tbi_ht; int tbi_mht ;
-         translate_global_bin_nbsum( bi, tbi_nj, tbi_htmht, tbi_ht, tbi_mht ) ;
-         h_nbsum_nj_bin_index -> SetBinContent( bi, tbi_nj ) ;
-         h_nbsum_htmht_bin_index -> SetBinContent( bi, tbi_htmht ) ;
-         h_nbsum_ht_bin_index -> SetBinContent( bi, tbi_ht ) ;
-         h_nbsum_mht_bin_index -> SetBinContent( bi, tbi_mht ) ;
-      } // bi
-
-      printf("\n\n") ;
-
-   } // setup_bins
 
 //=====================================================================================================
 
@@ -642,4 +524,4 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
 
    //===================================
 
-
+#endif

--- a/fill_data_hists_loop_v2d.h
+++ b/fill_data_hists_loop_v2d.h
@@ -22,27 +22,6 @@ class fill_data_hists_loop_v2d {
 public :
 
    //----------
-   float bin_edges_nj[100]  ;
-   float bin_edges_nb[100]  ;
-   float bin_edges_mht[100]  ;
-   float bin_edges_ht[100][100]  ;
-   int   nb_nj ;
-   int   nb_nb ;
-   int   nb_ht[100] ;
-   int   nb_mht ;
-   int   bi_nj ;
-   int   bi_nb ;
-   int   bi_ht ;
-   int   bi_mht ;
-
-   int   nb_htmht ;
-   int   bi_htmht ;
-
-   int   nb_global ;
-   int   bi_global ;
-   int   bi_nbsum_global ;
-
-   void setup_bins() ;
    void set_bi() ;
 
    void translate_global_bin( int gbi, int& tbi_nj, int& tbi_nb, int& tbi_htmht, int& tbi_ht, int& tbi_mht ) ;
@@ -204,12 +183,12 @@ fill_data_hists_loop_v2d::fill_data_hists_loop_v2d(TTree *tree, const char* samp
    // chain->Add("fnal-prod-v9-skims-slimmed/tree_signal/tree_MET_2016B-slimskim.root/tree");
    // chain->Add("fnal-prod-v9-skims-slimmed/tree_signal/tree_MET_2016C-slimskim.root/tree");
      //----------
-      chain->Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_MET_2016B-slimskim.root/tree");
-      chain->Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_MET_2016C-slimskim.root/tree");
-      chain->Add("fnal-prod-v9-skims-slimmed/tree_LDP_july21a/tree_MET_2016D-slimskim.root/tree");
-      chain->Add("fnal-prod-v9-skims-slimmed/tree_signal_july21a/tree_MET_2016B-slimskim.root/tree");
-      chain->Add("fnal-prod-v9-skims-slimmed/tree_signal_july21a/tree_MET_2016C-slimskim.root/tree");
-      chain->Add("fnal-prod-v9-skims-slimmed/tree_signal_july21a/tree_MET_2016D-slimskim.root/tree");
+      chain->Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016B-slimskim.root/tree");
+      chain->Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016C-slimskim.root/tree");
+      chain->Add("fnal-prod-v9-skims-slimmed/tree_LDP/tree_MET_2016D-slimskim.root/tree");
+      chain->Add("fnal-prod-v9-skims-slimmed/tree_signal/tree_MET_2016B-slimskim.root/tree");
+      chain->Add("fnal-prod-v9-skims-slimmed/tree_signal/tree_MET_2016C-slimskim.root/tree");
+      chain->Add("fnal-prod-v9-skims-slimmed/tree_signal/tree_MET_2016D-slimskim.root/tree");
      //----------
       tree = chain;
 #endif // SINGLE_TREE

--- a/fill_hists_loop_v2d.h
+++ b/fill_hists_loop_v2d.h
@@ -23,27 +23,7 @@ class fill_hists_loop_v2d {
 public :
 
    //----------
-   float bin_edges_nj[100]  ;
-   float bin_edges_nb[100]  ;
-   float bin_edges_mht[100]  ;
-   float bin_edges_ht[100][100]  ;
-   int   nb_nj ;
-   int   nb_nb ;
-   int   nb_ht[100] ;
-   int   nb_mht ;
-   int   bi_nj ;
-   int   bi_nb ;
-   int   bi_ht ;
-   int   bi_mht ;
 
-   int   nb_htmht ;
-   int   bi_htmht ;
-
-   int   nb_global ;
-   int   bi_global ;
-   int   bi_nbsum_global ;
-
-   void setup_bins() ;
    void set_bi() ;
 
    void translate_global_bin( int gbi, int& tbi_nj, int& tbi_nb, int& tbi_htmht, int& tbi_ht, int& tbi_mht ) ;

--- a/make_qcdmc_input_files1.c
+++ b/make_qcdmc_input_files1.c
@@ -1,19 +1,27 @@
+#include "TFile.h"
+#include "TDirectory.h"
+#include "TH1F.h"
+#include "TPad.h"
+#include "TStyle.h"
+#include "TString.h"
 
+#include "binning.h"
 
    void make_qcdmc_input_files1( const char* input_root_file = "outputfiles/hists-v2d-qcd.root",
                                  const char* nbsum_text_file = "outputfiles/nbsum-input-qcd.txt",
                                  const char* output_hist_file = "outputfiles/modelfit-input-qcdmc.root"
                                ) {
 
+      setup_bins();
       gDirectory -> Delete( "h*" ) ;
 
       TFile* tf = new TFile( input_root_file, "read" ) ;
       if ( tf == 0x0 ) { printf("\n\n *** Bad input file: %s\n\n", input_root_file ) ; return ; }
       if ( !(tf -> IsOpen() ) ) { printf("\n\n *** Bad input file: %s\n\n", input_root_file ) ; return ; }
 
-      printf("\n") ;
-      tf -> ls() ;
-      printf("\n") ;
+//      printf("\n") ;
+//      tf -> ls() ;
+//      printf("\n") ;
 
       FILE* ofp_nbsum ;
       if ( (ofp_nbsum = fopen( nbsum_text_file, "w" ))==NULL ) {
@@ -27,10 +35,9 @@
       TH1F* h_hdp = (TH1F*) tf -> Get( "h_hdp" ) ;
       if ( h_hdp == 0x0 ) { printf("\n\n *** Missing h_hdp\n\n") ; return ; }
 
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
+//      int nb_nj(5) ;
+//      int nb_nb(4) ;
+//      int nb_htmht(13) ;
 
       int bi_hist(0) ;
 
@@ -38,8 +45,8 @@
 
       int bi_ratio_hist(0) ;
 
-      for ( int bi_ht=1; bi_ht<=nb_ht; bi_ht++ ) {
-         for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
+      for ( bi_ht=1; bi_ht<=3; bi_ht++ ) {
+         for ( bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
 
             double ldp_nbsum_val(0.) ;
             double ldp_nbsum_err2(0.) ;
@@ -47,7 +54,7 @@
             double hdp_nbsum_val(0.) ;
             double hdp_nbsum_err2(0.) ;
 
-            for ( int bi_nb=1; bi_nb<=nb_nb; bi_nb++ ) {
+            for ( bi_nb=1; bi_nb<=nb_nb; bi_nb++ ) {
 
                bi_hist = (bi_nj-1)*(nb_nb)*(nb_htmht) + (bi_nb-1)*(nb_htmht) + bi_ht ;
 

--- a/make_qcdmc_input_files1.c
+++ b/make_qcdmc_input_files1.c
@@ -1,3 +1,6 @@
+#ifndef make_qcdmc_input_files1_c
+#define make_qcdmc_input_files1_c
+
 #include "TFile.h"
 #include "TDirectory.h"
 #include "TH1F.h"
@@ -141,4 +144,4 @@
    } // make_qcdmc_input_files1
 
 
-
+#endif

--- a/run_all.C
+++ b/run_all.C
@@ -1,5 +1,8 @@
 #include "slim-code/run_slimskim.c"
+
+#ifndef   data_turnon1_c
 #include "data_turnon1.c"
+#endif
 
 #include "TSystem.h"
 #include "TFile.h"

--- a/run_all.C
+++ b/run_all.C
@@ -1,0 +1,33 @@
+#include "slim-code/run_slimskim.c"
+#include "data_turnon1.c"
+
+#include "TSystem.h"
+#include "TFile.h"
+#include "TROOT.h"
+
+
+
+void run_all (bool do_skim_slim = false )
+
+{
+
+   //Adding necessary dictionaries
+   gROOT->ProcessLine(".L loader.C+");
+
+   //Run the slim code
+   if ( do_skim_slim == true )
+   {
+
+      run_slimskim("./fnal-prod-v9-skims/tree_signal");
+      run_slimskim("./fnal-prod-v9-skims/tree_LDP");
+
+      gSystem -> Exec("mkdir -p ./fnal-prod-v9-skims-skimmed/tree_signal");
+      gSystem -> Exec("mkdir -p ./fnal-prod-v9-skims-skimmed/tree_LDP");
+
+      gSystem -> Exec("mv ./fnal-prod-v9-skims/tree_signal/slim/* ./fnal-prod-v9-skims-slimmed/tree_signal");
+      gSystem -> Exec("mv ./fnal-prod-v9-skims/tree_LDP/slim/* ./fnal-prod-v9-skims-slimmed/tree_LDP");
+
+   }
+   data_turnon1();
+
+}

--- a/run_all.C
+++ b/run_all.C
@@ -1,21 +1,22 @@
 #include "slim-code/run_slimskim.c"
 
-#ifndef   data_turnon1_c
 #include "data_turnon1.c"
-#endif
+#include "fill_hists_loop_v2d.c"
+#include "fill_data_hists_loop_v2d.c"
 
 #include "TSystem.h"
 #include "TFile.h"
 #include "TROOT.h"
-
-
 
 void run_all (bool do_skim_slim = false )
 
 {
 
    //Adding necessary dictionaries
-   gROOT->ProcessLine(".L loader.C+");
+#ifdef __MAKECINT__
+#pragma link C++ class vector<TLorentzVector>+;
+#pragma link C++ class std::vector<bool>+;
+#endif
 
    //Run the slim code
    if ( do_skim_slim == true )
@@ -24,13 +25,20 @@ void run_all (bool do_skim_slim = false )
       run_slimskim("./fnal-prod-v9-skims/tree_signal");
       run_slimskim("./fnal-prod-v9-skims/tree_LDP");
 
-      gSystem -> Exec("mkdir -p ./fnal-prod-v9-skims-skimmed/tree_signal");
-      gSystem -> Exec("mkdir -p ./fnal-prod-v9-skims-skimmed/tree_LDP");
+      gSystem -> Exec("mkdir -p ./fnal-prod-v9-skims-slimmed/tree_signal");
+      gSystem -> Exec("mkdir -p ./fnal-prod-v9-skims-slimmed/tree_LDP");
 
       gSystem -> Exec("mv ./fnal-prod-v9-skims/tree_signal/slim/* ./fnal-prod-v9-skims-slimmed/tree_signal");
       gSystem -> Exec("mv ./fnal-prod-v9-skims/tree_LDP/slim/* ./fnal-prod-v9-skims-slimmed/tree_LDP");
 
    }
    data_turnon1();
+
+   fill_hists_loop_v2d f1;
+   f1.Loop();
+
+   fill_data_hists_loop_v2d f2;
+   f2.Loop();
+
 
 }

--- a/run_all.C
+++ b/run_all.C
@@ -3,6 +3,7 @@
 #include "data_turnon1.c"
 #include "fill_hists_loop_v2d.c"
 #include "fill_data_hists_loop_v2d.c"
+#include "make_qcdmc_input_files1.c"
 
 #include "TSystem.h"
 #include "TFile.h"
@@ -40,5 +41,5 @@ void run_all (bool do_skim_slim = false )
    fill_data_hists_loop_v2d f2;
    f2.Loop();
 
-
+   make_qcdmc_input_files1();
 }

--- a/slim-code/doSkimSlim.c
+++ b/slim-code/doSkimSlim.c
@@ -302,7 +302,7 @@ using std::vector ;
 
          if ( doSkim ) {
 
-            if ( NJets < 3 ) continue ;
+            if ( NJets < 2 ) continue ;  //** changed from 2 to 3
             if ( MHT < 200. ) continue ; //*** changed from 250 to 200.
             if ( HT < 300. ) continue ;
 


### PR DESCRIPTION
Hi Owen,

This is what I have done in this pull request:
1. I added two files to the repository

1-a: binning.h: I created a new file that determines the binning (It's a copy of setup_bins() function in 
fill_data_hists_loop_v2d.c ). My goal was to have a central definition of binning so if in the future we want to change the binning again, we would only need to change binning.h  and all other parts of the code would automatically inherit the changes in binning. 

1-b: run_all.C: This file will automatically produce all the plots and tables. In other words, my goal is to put all your instructions in this file so we can do everything automatically. I will add every file that I update (to include NJets = 2 option) to run_all.C so I will complete it step by step. 
This file has two options:  run_all(true) will also skim-slim the root files and then produce the results, However, run_all() will only produce the plots and tables using the existing root files. 
1. I have updated files doSkimSlim.c, data_turnon1.c, fill_data_hists_loop_v2d.c, fill_hists_loop_v2d.c, make_qcdmc_input_files1.c to inherit the binning from binning.h (and therefore being able to run with NJets = 2 included or excluded) 
2. In order to check if the updated files produce the correct results, I did two tests:

3.1: I turned off the NJets = 2 option (changed binning.h) and compared the results of updated and original codes. The results were exactly the same. 

3.2: I skim-slimed a set of root file with your original code (Excluding all NJets = 2 events). Then I turned on the NJets = 2 option in binning.h and compared the results of updated and original codes.  If I run the updated and original versions of the codes on this set of root files (skim-slimmed), the results should be the same. Because although the NJets = 2 option is on, there is no event with NJets = 2 in the root files (I removed them using your skim-slim code) therefore, all the plots related to NJets = 2 should be empty and other plots should be unchanged. After doing this, I saw that all the plots were unchanged (and NJets = 2 plots were empty)
1. Now I am working on updating modelfit3.c. As you know, this file will fit the QCD toy model parameters to match the data we have taken at CMS. However, I am not sure if you want to include NJets = 2 in fitting. I mean, do you want to do the fitting including NJets = 2 or you want to exclude NJets = 2, do the fitting and just check how well it matches the NJets = 2 area? I hope my question is clear!

Best,
Amin
