### PR TITLE
Updating files "make_data_input_files1.c", "make_lostlep_input_files1.c", "make_hadtau_input_files1.c","make_znunu_input_files1.c","  gen_modelfit_input1.c", "run_modelfit3_on_qcdmc_as_on_data.c", "syst_2015_v2.c","draw_qcd_ratio_v3.c",   "draw_badjet_cat_v3.c" and "   create_model_ratio_hist1.c"

### DIFF
--- a/binning.h
+++ b/binning.h
@@ -38,6 +38,7 @@ using namespace std ;
    int   bi_global ;
    int   bi_nbsum_global ;
 
+   int   njet_bin_to_fix_in_qcd_model_fit;
 
 //=====================================================================================================
 
@@ -48,6 +49,7 @@ using namespace std ;
       bi = 0 ;
 
       bin_edges_nj[bi] = 1.5 ; bi++ ; // *** adding NJets=2 binning
+      njet_bin_to_fix_in_qcd_model_fit  = bi; // Setting bin NJets = {3,4} as the bin to be fixed to one while fitting QCD toymodel parameters
       bin_edges_nj[bi] = 2.5 ; bi++ ;
       bin_edges_nj[bi] = 4.5 ; bi++ ;
       bin_edges_nj[bi] = 6.5 ; bi++ ;

--- a/create_model_pars_data3.c
+++ b/create_model_pars_data3.c
@@ -1,0 +1,69 @@
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <fstream>
+
+bool create_model_pars_data3()
+{
+
+    std::string filein_name = "outputfiles/data-chi2-fit-model-pars.txt";
+    std::string filein2_name = "outputfiles/model-pars-qcdmc3.txt";
+    std::string fileout_name = "outputfiles/model-pars-data3.txt";
+
+    
+    ifstream filein(filein_name);
+    ofstream fileout(fileout_name);
+    
+    if ( !filein ) { cout << "Warning: file " << filein_name <<" doesn't exist" << endl; return 0; }
+    if ( !fileout ) { cout << "Warning: cannot open/create file" << fileout_name << endl; return 0; }
+    
+    std::string line;
+    while( std::getline(filein,line) )
+    {
+        
+        std::size_t index = line.find("+/-");
+        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
+        line.replace( index, 3, "   ");
+        
+        index = line.find("(");
+        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
+        line.replace(line.find('('),line.find(')')-line.find('(')+1,"0.00");
+        
+        string val_str, name_str;       
+        stringstream convert_temp(line);
+        convert_temp >> name_str;
+        convert_temp >> val_str;
+        stringstream convert(val_str);
+        double val;
+        if ( !(convert >> val) )  { cout << val << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
+        fileout << line << std::endl;
+    }
+   filein.close();
+
+
+    ifstream filein2( filein2_name );
+    
+    if ( !filein2 ) { cout << "Warning: file " << filein2_name << " doesn't exist" << endl; return 0; }
+    
+    while( std::getline(filein2,line) )
+    {
+        
+        std::string val_str, name_str;       
+        stringstream convert_temp(line);
+        convert_temp >> name_str;
+        convert_temp >> val_str;
+        stringstream convert(val_str);
+        double val;
+        if ( !(convert >> val) )  { cout << val << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
+        if ( name_str.compare(5,3,"mht") == 0 || name_str.compare(5,2,"nb") == 0 )  
+           fileout << line << std::endl;
+    }
+   filein.close();
+
+
+
+
+
+   return 1;
+
+}

--- a/create_model_ratio_hist1.c
+++ b/create_model_ratio_hist1.c
@@ -1,3 +1,6 @@
+#ifndef create_model_ratio_hist1_c
+#define create_model_ratio_hist1_c
+
 #include "TSystem.h"
 #include "TPad.h"
 #include "TStyle.h"
@@ -256,12 +259,15 @@
             return ;
          }
       }
-
+//      std::cout << line_parname << ":" << pname << std::endl;
       printf("\n\n *** get_par : Failed to find parameter %s\n\n", pname ) ;
       gSystem -> Exit(-1) ;
 
    } // get_par
 //===============================================================================
+
+#ifndef get_hist_
+#define get_hist_
 
    TH1F* get_hist( const char* hname ) {
       TH1F* hp = (TH1F*) gDirectory -> FindObject( hname ) ;
@@ -273,5 +279,6 @@
       return hp ;
    } // get_hist
 
+#endif
 //===============================================================================
-
+#endif

--- a/create_model_ratio_hist1.c
+++ b/create_model_ratio_hist1.c
@@ -1,35 +1,25 @@
+#include "TSystem.h"
+#include "TPad.h"
+#include "TStyle.h"
+#include <fstream>
 
+#include "binning.h"
+#include "histio.c"
 
-      float par_val_ht[5] ;
-      float par_err_ht_fit[5] ;
-      float par_err_ht_syst[5] ;
+      float par_val_ht[10] ;
+      float par_err_ht_fit[10] ;
+      float par_err_ht_syst[10] ;
 
-      float par_val_njet[5] ;
-      float par_err_njet_fit[5] ;
-      float par_err_njet_syst[5] ;
+      float par_val_njet[10] ;
+      float par_err_njet_fit[10] ;
+      float par_err_njet_syst[10] ;
 
-      float par_val_mht_hth[6] ;
-      float par_err_mht_hth[6] ;
+      float par_val_ht_mht[10][10] ;
+      float par_err_ht_mht[10][10] ;
 
-      float par_val_mht_htm[6] ;
-      float par_err_mht_htm[6] ;
+      float par_val_nb[10] ;
+      float par_err_nb[10] ;
 
-      float par_val_mht_htl[6] ;
-      float par_err_mht_htl[6] ;
-
-      float par_val_nb[5] ;
-      float par_err_nb[5] ;
-
-
-      int   ht_ind[209] ;
-      int   nj_ind[209] ;
-      int   mht_ind[209] ;
-      int   nb_ind[209] ;
-
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
 
    void get_par( ifstream& ifs, const char* pname, float& val, float& err1, float& err2 ) ;
    void set_ht_and_mht_ind_from_htmht_ind( int bi_htmht, int& bi_ht, int& bi_mht ) ;
@@ -37,22 +27,20 @@
    TH1F* get_hist( const char* hname ) ;
 
 
-#include "histio.c"
-
-   void create_model_ratio_hist1( const char* model_pars_file = "model-pars-qcdmc4c.txt",
+   void create_model_ratio_hist1( const char* model_pars_file = "outputfiles/model-pars-qcdmc3.txt",
                                   const char* qcd_ratio_file = "outputfiles/qcdmc-ratio-v3.root" ) {
-
+      setup_bins(); 
       gDirectory -> Delete( "h*" ) ;
 
       loadHist( qcd_ratio_file, "qcdmc" ) ;
 
       read_pars( model_pars_file ) ;
 
-      TH1F* h_ratio_all = new TH1F( "h_ratio_all", "QCD model H/L ratio", 160, 0.5, 160.5 ) ;
+      TH1F* h_ratio_all = new TH1F( "h_ratio_all", "QCD model H/L ratio", (nb_htmht-3) * nb_nb * nb_nj, 0.5, (nb_htmht-3) * nb_nb * nb_nj + 0.5 ) ;
 
-      TH1F* h_max_ldp_weight_160bins = get_hist( "h_max_ldp_weight_160bins_qcdmc" ) ;
-      TH1F* h_ldp_160bins = get_hist( "h_ldp_160bins_qcdmc" ) ;
-      TH1F* h_hdp_160bins = get_hist( "h_hdp_160bins_qcdmc" ) ;
+      TH1F* h_max_ldp_weight_search_bins = get_hist( "h_max_ldp_weight_search_bins_qcdmc" ) ;
+      TH1F* h_ldp_search_bins = get_hist( "h_ldp_search_bins_qcdmc" ) ;
+      TH1F* h_hdp_search_bins = get_hist( "h_hdp_search_bins_qcdmc" ) ;
       TH1F* h_ratio_qcdmc = get_hist( "h_ratio_qcdmc" ) ;
 
       int bi_hist(0) ;
@@ -68,50 +56,24 @@
                char label[100] ;
                sprintf( label, " %3d Nj%d-Nb%d-MHT%d-HT%d (%d)", bi_hist, bi_nj, bi_nb-1, bi_mht-1, bi_ht, bi_htmht-3 ) ;
 
-               double model_ratio_val ;
-               double model_ratio_err ;
+               double model_ratio_val = 0;
+               double model_ratio_err = 0;
 
-               if ( bi_ht == 1 ) {
-                  model_ratio_val = par_val_ht[bi_ht] * par_val_njet[bi_nj] * par_val_mht_htl[bi_mht] * par_val_nb[bi_nb] ;
+                  model_ratio_val = par_val_ht[bi_ht] * par_val_njet[bi_nj] * par_val_ht_mht[bi_ht][bi_mht] * par_val_nb[bi_nb] ;
                   model_ratio_err = model_ratio_val * sqrt(
                          pow( par_err_ht_fit[bi_ht]/par_val_ht[bi_ht], 2. )
                       +  pow( par_err_ht_syst[bi_ht]/par_val_ht[bi_ht], 2. )
                       +  pow( par_err_njet_fit[bi_nj]/par_val_njet[bi_nj], 2. )
                       +  pow( par_err_njet_syst[bi_nj]/par_val_njet[bi_nj], 2. )
-                      +  pow( par_err_mht_htl[bi_mht]/par_val_mht_htl[bi_mht], 2. )
+                      +  pow( par_err_ht_mht[bi_ht][bi_mht]/par_val_ht_mht[bi_ht][bi_mht], 2. )
                       +  pow( par_err_nb[bi_nb]/par_val_nb[bi_nb], 2. )
                     ) ;
                   printf("  %s : Nj %6.4f Nb %6.4f MHT %6.4f HT %6.4f  model ratio = %6.4f +/- %6.4f\n", label,
-                    par_val_njet[bi_nj], par_val_nb[bi_nb], par_val_mht_htl[bi_mht], par_val_ht[bi_ht], model_ratio_val, model_ratio_err  ) ;
-               } else if ( bi_ht == 2 ) {
-                  model_ratio_val = par_val_ht[bi_ht] * par_val_njet[bi_nj] * par_val_mht_htm[bi_mht] * par_val_nb[bi_nb] ;
-                  model_ratio_err = model_ratio_val * sqrt(
-                         pow( par_err_ht_fit[bi_ht]/par_val_ht[bi_ht], 2. )
-                      +  pow( par_err_ht_syst[bi_ht]/par_val_ht[bi_ht], 2. )
-                      +  pow( par_err_njet_fit[bi_nj]/par_val_njet[bi_nj], 2. )
-                      +  pow( par_err_njet_syst[bi_nj]/par_val_njet[bi_nj], 2. )
-                      +  pow( par_err_mht_htm[bi_mht]/par_val_mht_htm[bi_mht], 2. )
-                      +  pow( par_err_nb[bi_nb]/par_val_nb[bi_nb], 2. )
-                    ) ;
-                  printf("  %s : Nj %6.4f Nb %6.4f MHT %6.4f HT %6.4f  model ratio = %6.4f +/- %6.4f\n", label,
-                    par_val_njet[bi_nj], par_val_nb[bi_nb], par_val_mht_htm[bi_mht], par_val_ht[bi_ht], model_ratio_val, model_ratio_err  ) ;
-               } else if ( bi_ht == 3 ) {
-                  model_ratio_val = par_val_ht[bi_ht] * par_val_njet[bi_nj] * par_val_mht_hth[bi_mht] * par_val_nb[bi_nb] ;
-                  model_ratio_err = model_ratio_val * sqrt(
-                         pow( par_err_ht_fit[bi_ht]/par_val_ht[bi_ht], 2. )
-                      +  pow( par_err_ht_syst[bi_ht]/par_val_ht[bi_ht], 2. )
-                      +  pow( par_err_njet_fit[bi_nj]/par_val_njet[bi_nj], 2. )
-                      +  pow( par_err_njet_syst[bi_nj]/par_val_njet[bi_nj], 2. )
-                      +  pow( par_err_mht_hth[bi_mht]/par_val_mht_hth[bi_mht], 2. )
-                      +  pow( par_err_nb[bi_nb]/par_val_nb[bi_nb], 2. )
-                    ) ;
-                  printf("  %s : Nj %6.4f Nb %6.4f MHT %6.4f HT %6.4f  model ratio = %6.4f +/- %6.4f\n", label,
-                    par_val_njet[bi_nj], par_val_nb[bi_nb], par_val_mht_hth[bi_mht], par_val_ht[bi_ht], model_ratio_val, model_ratio_err  ) ;
-               }
+                    par_val_njet[bi_nj], par_val_nb[bi_nb], par_val_ht_mht[bi_ht][bi_mht], par_val_ht[bi_ht], model_ratio_val, model_ratio_err  ) ;
 
                h_ratio_all -> GetXaxis() -> SetBinLabel( bi_hist, label ) ;
 
-               if ( bi_nj>2 && bi_ht==1 ) continue ;
+               if ( bi_nj>(nb_nj-2) && bi_ht==1 ) continue ; // skip top two njets bins for lowest HT.
 
                h_ratio_all -> SetBinContent( bi_hist, model_ratio_val ) ;
                h_ratio_all -> SetBinError( bi_hist, model_ratio_err ) ;
@@ -133,15 +95,15 @@
 
      //---------------
 
-      TH1F* h_ratio_qcdmc_minus_model = new TH1F( "h_ratio_qcdmc_minus_model", "QCD H/L ratio difference (QCD MC - model)", 160, 0.5, 160.5 ) ;
+      TH1F* h_ratio_qcdmc_minus_model = new TH1F( "h_ratio_qcdmc_minus_model", "QCD H/L ratio difference (QCD MC - model)", (nb_htmht-3) * nb_nb * nb_nj, 0.5, (nb_htmht-3) * nb_nb * nb_nj + 0.5 ) ;
 
       printf("\n\n") ;
-      for ( int bi=1; bi<=160; bi++ ) {
+      for ( int bi=1; bi<=(nb_htmht-3) * nb_nb * nb_nj; bi++ ) { //loop over search bins
          float model_val = h_ratio_all -> GetBinContent( bi ) ;
          float qcdmc_val = h_ratio_qcdmc -> GetBinContent( bi ) ;
-         float ldp_val = h_ldp_160bins -> GetBinContent( bi ) ;
-         float hdp_val = h_hdp_160bins -> GetBinContent( bi ) ;
-         float max_ldp_weight = h_max_ldp_weight_160bins -> GetBinContent( bi ) ;
+         float ldp_val = h_ldp_search_bins -> GetBinContent( bi ) ;
+         float hdp_val = h_hdp_search_bins -> GetBinContent( bi ) ;
+         float max_ldp_weight = h_max_ldp_weight_search_bins -> GetBinContent( bi ) ;
          char label[100] ;
          sprintf( label, "%s", h_ratio_all -> GetXaxis() -> GetBinLabel( bi ) ) ;
          float diff_val(0.) ;
@@ -187,168 +149,59 @@
          char pname[100] ;
 
        //---
-         sprintf( pname, "Kqcd_HT1" ) ;
+
+         for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) 
+         {
+         sprintf( pname, "Kqcd_HT%d",bi_ht ) ;
          get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_ht[1] = val ;
-         par_err_ht_fit[1] = err1 ;
-         par_err_ht_syst[1] = val*err2 ;
+         par_val_ht     [bi_ht] = val ;
+         par_err_ht_fit [bi_ht] = err1 ;
+         par_err_ht_syst[bi_ht] = val*err2 ;
          printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
 
-         sprintf( pname, "Kqcd_HT2" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_ht[2] = val ;
-         par_err_ht_fit[2] = err1 ;
-         par_err_ht_syst[2] = val*err2 ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Kqcd_HT3" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_ht[3] = val ;
-         par_err_ht_fit[3] = err1 ;
-         par_err_ht_syst[3] = val*err2 ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
+         }
        //---
-         sprintf( pname, "Sqcd_njet1" ) ;
+         for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ )  
+         {
+         sprintf( pname, "Sqcd_njet%d",bi_nj ) ;
          get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_njet[1] = val ;
-         par_err_njet_fit[1] = err1 ;
-         par_err_njet_syst[1] = val*err2 ;
+         par_val_njet     [bi_nj] = val ;
+         par_err_njet_fit [bi_nj] = err1 ;
+         par_err_njet_syst[bi_nj] = val*err2 ;
          printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
 
-         sprintf( pname, "Sqcd_njet2" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_njet[2] = val ;
-         par_err_njet_fit[2] = err1 ;
-         par_err_njet_syst[2] = val*err2 ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_njet3" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_njet[3] = val ;
-         par_err_njet_fit[3] = err1 ;
-         par_err_njet_syst[3] = val*err2 ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_njet4" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_njet[4] = val ;
-         par_err_njet_fit[4] = err1 ;
-         par_err_njet_syst[4] = val*err2 ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
+         }
 
 
        //---
-         sprintf( pname, "Sqcd_mhtc_hth" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_hth[1] = val ;
-         par_err_mht_hth[1] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
+         for ( int bi_ht =1; bi_ht<=nBinsHT; bi_ht++ )
+         for ( int bi_mht=0; bi_mht<nb_mht; bi_mht++ )
+         {
+         char ht_level [10], mhtc[10] = "c";
+         if ( bi_ht == 1 ) strcpy(ht_level, "hth");
+         if ( bi_ht == 2 ) strcpy(ht_level, "htm");
+         if ( bi_ht == 3 ) strcpy(ht_level, "htl");
 
-         sprintf( pname, "Sqcd_mht1_hth" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_hth[2] = val ;
-         par_err_mht_hth[2] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
+         if ( bi_ht == 3 && bi_mht > 2 ) continue;
 
-         sprintf( pname, "Sqcd_mht2_hth" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_hth[3] = val ;
-         par_err_mht_hth[3] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
+         if ( bi_mht == 0 ) sprintf( pname, "Sqcd_mht%s_%s",mhtc  , ht_level ) ;
+         else               sprintf( pname, "Sqcd_mht%d_%s",bi_mht, ht_level ) ;
 
-         sprintf( pname, "Sqcd_mht3_hth" ) ;
          get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_hth[4] = val ;
-         par_err_mht_hth[4] = sqrt( err1*err1 + val*val*err2*err2 ) ;
+         par_val_ht_mht[nBinsHT - bi_ht + 1][bi_mht+1] = val ;
+         par_err_ht_mht[nBinsHT - bi_ht + 1][bi_mht+1] = sqrt( err1*err1 + val*val*err2*err2 ) ;
          printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht4_hth" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_hth[5] = val ;
-         par_err_mht_hth[5] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
+         }
        //---
-         sprintf( pname, "Sqcd_mhtc_htm" ) ;
+
+         for ( int bi_nb=0; bi_nb<nb_nb; bi_nb++ )
+         {
+         sprintf( pname, "Sqcd_nb%d",bi_nb ) ;
          get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htm[1] = val ;
-         par_err_mht_htm[1] = sqrt( err1*err1 + val*val*err2*err2 ) ;
+         par_val_nb[bi_nb+1] = val ;
+         par_err_nb[bi_nb+1] = sqrt( err1*err1 + val*val*err2*err2 ) ;
          printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht1_htm" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htm[2] = val ;
-         par_err_mht_htm[2] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht2_htm" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htm[3] = val ;
-         par_err_mht_htm[3] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht3_htm" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htm[4] = val ;
-         par_err_mht_htm[4] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht4_htm" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htm[5] = val ;
-         par_err_mht_htm[5] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-       //---
-         sprintf( pname, "Sqcd_mhtc_htl" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htl[1] = val ;
-         par_err_mht_htl[1] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht1_htl" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htl[2] = val ;
-         par_err_mht_htl[2] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_mht2_htl" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_mht_htl[3] = val ;
-         par_err_mht_htl[3] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-
-
-
-
-       //---
-         sprintf( pname, "Sqcd_nb0" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_nb[1] = val ;
-         par_err_nb[1] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_nb1" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_nb[2] = val ;
-         par_err_nb[2] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_nb2" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_nb[3] = val ;
-         par_err_nb[3] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
-         sprintf( pname, "Sqcd_nb3" ) ;
-         get_par( ifs_model_pars, pname, val, err1, err2 ) ;
-         par_val_nb[4] = val ;
-         par_err_nb[4] = sqrt( err1*err1 + val*val*err2*err2 ) ;
-         printf("   Read %s : %.4f %.4f %.4f\n", pname, val, err1, err2 ) ;
-
+         }
       } // read_pars
 
   //=======================================================================================

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -500,7 +500,8 @@ void draw_badjet_cat_v3(const char* infile = "outputfiles/syst-2015-v2.root" ) {
 
    for ( int nb_count = 0; nb_count < nb_nb; nb_count++)
          fprintf( out_file, "Sqcd_nb%d        1.000000     0.00000  0.00\n", nb_count) ;
-
+   fclose(out_file);
+   delete tf;
    } // draw_badjet_cat_v3
 
 bool transfer_qcd_parameters(string filein_name, string fileout_name)
@@ -518,11 +519,11 @@ bool transfer_qcd_parameters(string filein_name, string fileout_name)
     {
 
         std::size_t index = line.find("+/-");
-        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected"; return 0; }
+        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
         line.replace( index, 3, "   ");
 
         index = line.find("(");
-        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected"; return 0; }
+        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
         line.replace(line.find('('),line.find(')')-line.find('(')+1,"0.00");
 
         string var_str, name_str;        
@@ -531,9 +532,9 @@ bool transfer_qcd_parameters(string filein_name, string fileout_name)
         convert_temp >> var_str;
         stringstream convert(var_str);
         double val;
-        if ( !(convert >> val) )  { cout << val << "Warning: The structure of file " << filein_name << "is not as expected"; return 0; }
+        if ( !(convert >> val) )  { cout << val << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
         fileout << line << std::endl;
     }    
-
+   filein.close();fileout.close();
    return 1;
 }//transfer_qcd_parameters

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -1,13 +1,20 @@
+#include "TDirectory.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TH1F.h"
+#include "TLegend.h"
+#include "TStyle.h"
+#include "TText.h"
+#include "TLine.h"
 
+#include "binning.h"
 
-   void draw_badjet_cat_v3( const char* htstr = "hth", const char* infile = "outputfiles/syst-2015-v2.root" ) {
+   void amin( const char* htstr = "hth", const char* infile = "outputfiles/syst-2015-v2.root" ) {
 
          char fname[10000] ;
 
       gStyle -> SetOptStat(0) ;
-
-      int nbins(5) ;
-      if ( strcmp( htstr, "htl" ) == 0 ) { nbins = 3 ; }
+      setup_bins();
 
       TFile* tf = new TFile( infile, "READ" ) ;
       if ( ! tf -> IsOpen() ) { printf( "\n\n *** Bad input file: %s\n\n", infile ) ; return ; }
@@ -16,10 +23,9 @@
 
       TCanvas* can = new TCanvas( "can_draw_badjet_cat", "", 800, 600 ) ;
 
+      int nbins(5) ;
+
       float histshift(0.03) ;
-      TH1F* h_rhl_bj_in_dphi = new TH1F( "h_rhl_bj_in_dphi", "Rhigh/low, bad jet in dphi", nbins, 0.5-histshift, nbins+0.5-histshift ) ;
-      TH1F* h_fmissfpass_bj_in_dphi = new TH1F( "h_fmissfpass_bj_in_dphi", "Fr(bj not in dphi)*fr(pass)", nbins, 0.5+histshift, nbins+0.5+histshift ) ;
-      TH1F* h_rprime = new TH1F( "h_rprime", "Effective Rhigh/low", nbins, 0.5, nbins+0.5 ) ;
 
       //double fmiss_val = 0.022 ;
       //double fmiss_err = 0.004 ;
@@ -32,6 +38,24 @@
    // fmiss_val[3] = 0.018 ;  fmiss_err[3] = 0.001 ;
    // fmiss_val[4] = 0.012 ;  fmiss_err[4] = 0.002 ;
    // fmiss_val[5] = 0.011 ;  fmiss_err[5] = 0.002 ;
+   
+
+   for ( int ht_level = 0; ht_level < nBinsHT; ht_level++)
+   {
+
+      if ( ht_level == 0 ) htstr = "htl";
+      if ( ht_level == 1 ) htstr = "htm";
+      if ( ht_level == 2 ) htstr = "hth";
+
+      TString ht_str;
+      TH1F* h_rhl_bj_in_dphi = new TH1F( "h_rhl_bj_in_dphi", "Rhigh/low, bad jet in dphi", nbins, 0.5-histshift, nbins+0.5-histshift ) ;
+      TH1F* h_fmissfpass_bj_in_dphi = new TH1F( "h_fmissfpass_bj_in_dphi", "Fr(bj not in dphi)*fr(pass)", nbins, 0.5+histshift, nbins+0.5+histshift ) ;
+      TH1F* h_rprime = new TH1F( "h_rprime", "Effective Rhigh/low", nbins, 0.5, nbins+0.5 ) ;
+
+ 
+      nbins = 5 ;
+      if ( strcmp( htstr, "htl" ) == 0 ) { nbins = 3 ; }
+
 
       for ( int mbi=1; mbi<=nbins; mbi++ ) {
 
@@ -41,11 +65,11 @@
          TH1F* hp_all = (TH1F*) tf -> Get( hname ) ;
          if ( hp_all == 0x0 ) { printf("\n\n *** missing %s\n\n", hname ) ; return ; }
 
-         if ( mbi==1 ) { sprintf( hname, "h_mdp_%s_mhtc_badj_in_dphi", htstr ) ; } else { sprintf( hname, "h_mdp_%s_mht%d_badj_in_dphi", htstr, mbi-1 ) ; }
+         if ( mbi==1 ) { sprintf( hname, "h_mdp_%s_badj_in_dphi_mhtc", htstr ) ; } else { sprintf( hname, "h_mdp_%s_badj_in_dphi_mht%d", htstr, mbi-1 ) ; }
          TH1F* hp_bj_in_dphi = (TH1F*) tf -> Get( hname ) ;
          if ( hp_bj_in_dphi == 0x0 ) { printf("\n\n *** missing %s\n\n", hname ) ; return ; }
 
-         if ( mbi==1 ) { sprintf( hname, "h_mdp_%s_mhtc_badj_not_in_dphi", htstr ) ; } else { sprintf( hname, "h_mdp_%s_mht%d_badj_not_in_dphi", htstr, mbi-1 ) ; }
+         if ( mbi==1 ) { sprintf( hname, "h_mdp_%s_badj_not_in_dphi_mhtc", htstr ) ; } else { sprintf( hname, "h_mdp_%s_badj_not_in_dphi_mht%d", htstr, mbi-1 ) ; }
          TH1F* hp_bj_not_in_dphi = (TH1F*) tf -> Get( hname ) ;
          if ( hp_bj_not_in_dphi == 0x0 ) { printf("\n\n *** missing %s\n\n", hname ) ; return ; }
 
@@ -56,11 +80,11 @@
          TH1F* hp_dphiregion_all = (TH1F*) tf -> Get( hname ) ;
          if ( hp_dphiregion_all == 0x0 ) { printf("\n\n *** missing%s\n\n", hname ) ; return ; }
 
-         if ( mbi==1 ) { sprintf( hname, "h_dphiregion_%s_mhtc_badj_in_dphi", htstr ) ; } else { sprintf( hname, "h_dphiregion_%s_mht%d_badj_in_dphi", htstr, mbi-1 ) ; }
+         if ( mbi==1 ) { sprintf( hname, "h_dphiregion_%s_badj_in_dphi_mhtc", htstr ) ; } else { sprintf( hname, "h_dphiregion_%s_badj_in_dphi_mht%d", htstr, mbi-1 ) ; }
          TH1F* hp_dphiregion_bj_in_dphi = (TH1F*) tf -> Get( hname ) ;
          if ( hp_dphiregion_bj_in_dphi == 0x0 ) { printf("\n\n *** missing%s\n\n", hname ) ; return ; }
 
-         if ( mbi==1 ) { sprintf( hname, "h_dphiregion_%s_mhtc_badj_not_in_dphi", htstr ) ; } else { sprintf( hname, "h_dphiregion_%s_mht%d_badj_not_in_dphi", htstr, mbi-1 ) ; }
+         if ( mbi==1 ) { sprintf( hname, "h_dphiregion_%s_badj_not_in_dphi_mhtc", htstr ) ; } else { sprintf( hname, "h_dphiregion_%s_badj_not_in_dphi_mht%d", htstr, mbi-1 ) ; }
          TH1F* hp_dphiregion_bj_not_in_dphi = (TH1F*) tf -> Get( hname ) ;
          if ( hp_dphiregion_bj_not_in_dphi == 0x0 ) { printf("\n\n *** missing%s\n\n", hname ) ; return ; }
 
@@ -433,7 +457,7 @@
       h_dr -> Draw("same") ;
       h_dr -> Draw("axis same" ) ;
       h_dr -> Draw("axig same" ) ;
-
+}//ht_level
 
    } // draw_badjet_cat_v3
 

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -6,22 +6,40 @@
 #include "TStyle.h"
 #include "TText.h"
 #include "TLine.h"
-
+#include <fstream>
 #include "binning.h"
+#include <iostream>
+#include <string>
+#include <sstream>
 
-   void amin( const char* htstr = "hth", const char* infile = "outputfiles/syst-2015-v2.root" ) {
+bool transfer_qcd_parameters(string filein_name, string fileout_name);
 
-         char fname[10000] ;
+void draw_badjet_cat_v3(const char* infile = "outputfiles/syst-2015-v2.root" ) {
 
+      char fname[10000] ;
+      char htstr[10];
       gStyle -> SetOptStat(0) ;
       setup_bins();
 
       TFile* tf = new TFile( infile, "READ" ) ;
       if ( ! tf -> IsOpen() ) { printf( "\n\n *** Bad input file: %s\n\n", infile ) ; return ; }
 
+      FILE * out_file;
+
+      if ( transfer_qcd_parameters("./outputfiles/qcdmc-chi2-fit-model-pars.txt","./outputfiles/model-pars-qcdmc3.txt") )
+      {
+         out_file = fopen ("./outputfiles/model-pars-qcdmc3.txt","a");// "a" for append
+      }
+      else 
+         out_file = fopen ("./outputfiles/model-pars-qcdmc3.txt","w");// "w" for write
+      
+
+
+
       gDirectory -> Delete( "h*" ) ;
 
       TCanvas* can = new TCanvas( "can_draw_badjet_cat", "", 800, 600 ) ;
+      TCanvas* can2 = new TCanvas( "can2_draw_badjet_cat", "", 500, 600 ) ;
 
       int nbins(5) ;
 
@@ -40,17 +58,18 @@
    // fmiss_val[5] = 0.011 ;  fmiss_err[5] = 0.002 ;
    
 
-   for ( int ht_level = 0; ht_level < nBinsHT; ht_level++)
+   for ( int ht_level = nBinsHT-1; ht_level >= 0; ht_level--)
    {
 
-      if ( ht_level == 0 ) htstr = "htl";
-      if ( ht_level == 1 ) htstr = "htm";
-      if ( ht_level == 2 ) htstr = "hth";
+      if ( ht_level == 0 ) strcpy (htstr, "htl");
+      if ( ht_level == 1 ) strcpy (htstr, "htm");
+      if ( ht_level == 2 ) strcpy (htstr, "hth");
 
-      TString ht_str;
-      TH1F* h_rhl_bj_in_dphi = new TH1F( "h_rhl_bj_in_dphi", "Rhigh/low, bad jet in dphi", nbins, 0.5-histshift, nbins+0.5-histshift ) ;
-      TH1F* h_fmissfpass_bj_in_dphi = new TH1F( "h_fmissfpass_bj_in_dphi", "Fr(bj not in dphi)*fr(pass)", nbins, 0.5+histshift, nbins+0.5+histshift ) ;
-      TH1F* h_rprime = new TH1F( "h_rprime", "Effective Rhigh/low", nbins, 0.5, nbins+0.5 ) ;
+      TString ht_str = htstr;
+
+      TH1F* h_rhl_bj_in_dphi = new TH1F( "h_rhl_bj_in_dphi_"+ht_str, "Rhigh/low, bad jet in dphi", nbins, 0.5-histshift, nbins+0.5-histshift ) ;
+      TH1F* h_fmissfpass_bj_in_dphi = new TH1F( "h_fmissfpass_bj_in_dphi_"+ht_str, "Fr(bj not in dphi)*fr(pass)", nbins, 0.5+histshift, nbins+0.5+histshift ) ;
+      TH1F* h_rprime = new TH1F( "h_rprime_"+ht_str, "Effective Rhigh/low", nbins, 0.5, nbins+0.5 ) ;
 
  
       nbins = 5 ;
@@ -353,8 +372,6 @@
       TH1F* h_fmissfpass_bj_in_dphi_c = (TH1F*) h_fmissfpass_bj_in_dphi -> Clone( "h_fmissfpass_bj_in_dphi_c" ) ;
       TH1F* h_rhl_bj_in_dphi_c = (TH1F*) h_rhl_bj_in_dphi -> Clone( "h_rhl_bj_in_dphi_c" ) ;
 
-      TCanvas* can2 = new TCanvas( "can2_draw_badjet_cat", "", 500, 600 ) ;
-
       h_rprime -> SetMarkerStyle( 20 ) ;
       h_rprime -> SetLineWidth( 2 ) ;
       h_rprime_c -> SetLineWidth( 2 ) ;
@@ -411,12 +428,17 @@
     //   DR and syst
 
       printf("\n\n\n") ;
-      TH1F* h_dr = new TH1F( "h_dr", "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
-      TH1F* h_dr_stat = new TH1F( "h_dr_stat", "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
-      TH1F* h_dr_syst = new TH1F( "h_dr_syst", "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
-      TH1F* h_dr_total = new TH1F( "h_dr_total", "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
+      TH1F* h_dr = new TH1F( "h_dr_"+ht_str, "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
+      TH1F* h_dr_stat = new TH1F( "h_dr_stat_"+ht_str, "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
+      TH1F* h_dr_syst = new TH1F( "h_dr_syst_"+ht_str, "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
+      TH1F* h_dr_total = new TH1F( "h_dr_total_"+ht_str, "double ratio", nbins-1, 0.5, nbins-1+0.5 ) ;
       double rc_val = h_rprime -> GetBinContent(1) ;
       double rc_err = h_rprime -> GetBinError(1) ;
+
+         fprintf( out_file, "Sqcd_mhtc_%3s   1.000000     0.00000  0.00\n", htstr) ;
+
+      double store_val = 0, store_rel_err = 0;
+      char store_htstr[10];
       for ( int bi=2; bi<=nbins; bi++ ) {
          double r_val = h_rprime -> GetBinContent(bi) ;
          double r_err = h_rprime -> GetBinError(bi) ;
@@ -436,6 +458,23 @@
          if ( dr_val > 0 ) dr_rel_err = dr_total / dr_val ;
          printf("  MHT%d :  DR = (%6.4f +/- %6.4f) / ( %6.4f +/- %6.4f) = %6.4f +/- %6.4f (%6.4f, %6.4f), %5.0f%%\n",
             bi-1, r_val, r_err, rc_val, rc_err, dr_val, dr_total, dr_stat, dr_syst, 100*dr_rel_err ) ;
+
+        /// if the variable is equal to zero, equate it to the previous value in the list (if it is not the first variable of its kind)
+
+         if ( dr_val == 0. && bi!=2)
+         { 
+            fprintf( out_file, "Sqcd_mht%d_%3s   %3.6f     0.00000  %3.2f\n", bi-1, htstr,store_val,store_rel_err) ;
+            printf("===================================================================================================================\n");
+            printf("Warning: This code automatically set Sqcd_mht%d_%3s = Sqcd_mht%d_%3s, because Sqcd_mht%d_%3s was equal to zero\n", bi-1, htstr,bi-2, store_htstr, bi-1,htstr);
+            printf("===================================================================================================================\n");
+
+         }
+         else
+            fprintf( out_file, "Sqcd_mht%d_%3s   %3.6f     0.00000  %3.2f\n", bi-1, htstr,dr_val,dr_rel_err) ;
+
+         store_val = dr_val;
+         store_rel_err = dr_rel_err;
+         strcpy(store_htstr,htstr);
          h_dr -> SetBinContent( bi-1, dr_val ) ;
          h_dr -> SetBinError( bi-1, 0.0000001 ) ;
          h_dr_stat -> SetBinContent( bi-1, dr_val ) ;
@@ -457,13 +496,44 @@
       h_dr -> Draw("same") ;
       h_dr -> Draw("axis same" ) ;
       h_dr -> Draw("axig same" ) ;
-}//ht_level
+   }//ht_level
+
+   for ( int nb_count = 0; nb_count < nb_nb; nb_count++)
+         fprintf( out_file, "Sqcd_nb%d        1.000000     0.00000  0.00\n", nb_count) ;
 
    } // draw_badjet_cat_v3
 
+bool transfer_qcd_parameters(string filein_name, string fileout_name)
+{
 
 
+    ifstream filein(filein_name);
+    ofstream fileout(fileout_name);
 
+    if ( !filein ) { cout << "Warning: file " << filein_name <<" doesn't exist" << endl; return 0; }
+    if ( !filein ) { cout << "Warning: cannot open/create file" << fileout_name << endl; return 0; }
 
+    std::string line;
+    while( std::getline(filein,line) )
+    {
 
+        std::size_t index = line.find("+/-");
+        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected"; return 0; }
+        line.replace( index, 3, "   ");
 
+        index = line.find("(");
+        if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected"; return 0; }
+        line.replace(line.find('('),line.find(')')-line.find('(')+1,"0.00");
+
+        string var_str, name_str;        
+        stringstream convert_temp(line);
+        convert_temp >> name_str;
+        convert_temp >> var_str;
+        stringstream convert(var_str);
+        double val;
+        if ( !(convert >> val) )  { cout << val << "Warning: The structure of file " << filein_name << "is not as expected"; return 0; }
+        fileout << line << std::endl;
+    }    
+
+   return 1;
+}//transfer_qcd_parameters

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -512,7 +512,7 @@ bool transfer_qcd_parameters(string filein_name, string fileout_name)
     ofstream fileout(fileout_name);
 
     if ( !filein ) { cout << "Warning: file " << filein_name <<" doesn't exist" << endl; return 0; }
-    if ( !filein ) { cout << "Warning: cannot open/create file" << fileout_name << endl; return 0; }
+    if ( !fileout ) { cout << "Warning: cannot open/create file" << fileout_name << endl; return 0; }
 
     std::string line;
     while( std::getline(filein,line) )

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -463,9 +463,9 @@ void draw_badjet_cat_v3(const char* infile = "outputfiles/syst-2015-v2.root" ) {
 
          if ( dr_val == 0. && bi!=2)
          { 
-            fprintf( out_file, "Sqcd_mht%d_%3s   %3.6f     0.00000  %3.2f\n", bi-1, htstr,store_val,store_rel_err) ;
+            fprintf( out_file, "Sqcd_mht%d_%3s   %3.6f     0.00000   1.00f\n", bi-1, htstr,store_val) ;
             printf("===================================================================================================================\n");
-            printf("Warning: This code automatically set Sqcd_mht%d_%3s = Sqcd_mht%d_%3s, because Sqcd_mht%d_%3s was equal to zero\n", bi-1, htstr,bi-2, store_htstr, bi-1,htstr);
+            printf("Warning: I automatically set Sqcd_mht%d_%3s = Sqcd_mht%d_%3s and relative error = 1, because Sqcd_mht%d_%3s was equal to zero\n", bi-1, htstr,bi-2, store_htstr, bi-1,htstr);
             printf("===================================================================================================================\n");
 
          }

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -463,7 +463,7 @@ void draw_badjet_cat_v3(const char* infile = "outputfiles/syst-2015-v2.root" ) {
 
          if ( dr_val == 0. && bi!=2)
          { 
-            fprintf( out_file, "Sqcd_mht%d_%3s   %3.6f     0.00000   1.00f\n", bi-1, htstr,store_val) ;
+            fprintf( out_file, "Sqcd_mht%d_%3s   %3.6f     0.00000  1.00\n", bi-1, htstr,store_val) ;
             printf("===================================================================================================================\n");
             printf("Warning: I automatically set Sqcd_mht%d_%3s = Sqcd_mht%d_%3s and relative error = 1, because Sqcd_mht%d_%3s was equal to zero\n", bi-1, htstr,bi-2, store_htstr, bi-1,htstr);
             printf("===================================================================================================================\n");

--- a/draw_badjet_cat_v3.c
+++ b/draw_badjet_cat_v3.c
@@ -526,11 +526,11 @@ bool transfer_qcd_parameters(string filein_name, string fileout_name)
         if (index == std::string::npos) { cout << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
         line.replace(line.find('('),line.find(')')-line.find('(')+1,"0.00");
 
-        string var_str, name_str;        
+        string val_str, name_str;        
         stringstream convert_temp(line);
         convert_temp >> name_str;
-        convert_temp >> var_str;
-        stringstream convert(var_str);
+        convert_temp >> val_str;
+        stringstream convert(val_str);
         double val;
         if ( !(convert >> val) )  { cout << val << "Warning: The structure of file " << filein_name << "is not as expected";filein.close();fileout.close(); return 0; }
         fileout << line << std::endl;

--- a/draw_qcd_ratio_v3.c
+++ b/draw_qcd_ratio_v3.c
@@ -6,22 +6,19 @@
 #include "TCanvas.h"
 #include "TLine.h"
 
-
+#include "binning.h"
 #include "histio.c"
 
    TH1F* get_hist( const char* hname ) ;
    void  draw_boundaries() ;
    void  draw_boundaries_nj( int nhtb ) ;
 
-   const int nb_nj(4) ;
-   const int nb_nb(4) ;
-   const int nb_mht(5) ;
-   const int nb_htmht(13) ;
 
    //---------
 
    void draw_qcd_ratio_v3( const char* infile = "outputfiles/hists-v2d-qcd.root", const char* outputdir = "outputfiles/" ) {
-
+     
+      setup_bins();
       TLine* line0 = new TLine() ;
       line0 -> SetLineColor(4) ;
       TString tstring ;
@@ -49,17 +46,27 @@
       TH1F* h_max_ldp_weight = get_hist( "h_max_ldp_weight" ) ;
 
       TH1F* h_ratio = new TH1F( "h_ratio", "QCD H/L ratio", 160, 0.5, 160.5 ) ;
-      TH1F* h_ratio_nb0 = new TH1F( "h_ratio_nb0", "QCD H/L ratio, Nb0", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nb1 = new TH1F( "h_ratio_nb1", "QCD H/L ratio, Nb1", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nb2 = new TH1F( "h_ratio_nb2", "QCD H/L ratio, Nb2", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nb3 = new TH1F( "h_ratio_nb3", "QCD H/L ratio, Nb3", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nj1 = new TH1F( "h_ratio_nj1", "QCD H/L ratio, Nj1", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nj2 = new TH1F( "h_ratio_nj2", "QCD H/L ratio, Nj2", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nj3 = new TH1F( "h_ratio_nj3", "QCD H/L ratio, Nj3", 40, 0.5, 40.5 ) ;
-      TH1F* h_ratio_nj4 = new TH1F( "h_ratio_nj4", "QCD H/L ratio, Nj4", 40, 0.5, 40.5 ) ;
       TH1F* h_max_ldp_weight_160bins = new TH1F( "h_max_ldp_weight_160bins", "max LDP weight", 160, 0.5, 160.5 ) ;
       TH1F* h_ldp_160bins = new TH1F( "h_ldp_160bins", "LDP counts, 160 bins", 160, 0.5, 160.5 ) ;
       TH1F* h_hdp_160bins = new TH1F( "h_hdp_160bins", "HDP counts, 160 bins", 160, 0.5, 160.5 ) ;
+
+      TH1F * h_ratio_nb[10], * h_ratio_nj[10];
+
+      for ( int nb_count = 0; nb_count < nb_nb; nb_count++)
+      {
+
+      TString nb_str; nb_str.Form("%d",nb_count);
+      h_ratio_nb[nb_count] = new TH1F( "h_ratio_nb"+nb_str, "QCD H/L ratio, Nb"+nb_str, 40, 0.5, 40.5 ) ;
+
+      }
+
+      for ( int nj_count = 1; nj_count <= nb_nj; nj_count++)
+      {
+
+      TString nj_str; nj_str.Form("%d",nj_count);
+      h_ratio_nj[nj_count] = new TH1F( "h_ratio_nj"+nj_str, "QCD H/L ratio, Nj"+nj_str, 40, 0.5, 40.5 ) ;
+
+      }
 
       int bi_hist(0) ;
       int bi_search_hist(0) ;
@@ -94,19 +101,13 @@
                   h_hdp_160bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
                   printf( "  search %3d : %30s : R= %6.4f +/- %6.4f\n", bi_search_hist, label, ratio_val, ratio_err ) ;
                   TH1F* hp_nb(0x0) ;
-                  if ( bi_nb==1 ) hp_nb = h_ratio_nb0 ;
-                  if ( bi_nb==2 ) hp_nb = h_ratio_nb1 ;
-                  if ( bi_nb==3 ) hp_nb = h_ratio_nb2 ;
-                  if ( bi_nb==4 ) hp_nb = h_ratio_nb3 ;
+                  hp_nb = h_ratio_nb[bi_nb-1] ;
                   int bi_nb_hist = (bi_nj-1)*10 + bi_htmht-3 ;
                   hp_nb -> SetBinContent( bi_nb_hist, ratio_val ) ;
                   hp_nb -> SetBinError( bi_nb_hist, ratio_err ) ;
                   hp_nb -> GetXaxis() -> SetBinLabel( bi_nb_hist, label ) ;
                   TH1F* hp_nj(0x0) ;
-                  if ( bi_nj==1 ) hp_nj = h_ratio_nj1 ;
-                  if ( bi_nj==2 ) hp_nj = h_ratio_nj2 ;
-                  if ( bi_nj==3 ) hp_nj = h_ratio_nj3 ;
-                  if ( bi_nj==4 ) hp_nj = h_ratio_nj4 ;
+                  hp_nj = h_ratio_nj[bi_nj] ;
                   int bi_nj_hist = (bi_nb-1)*10 + bi_htmht-3 ;
                   hp_nj -> SetBinContent( bi_nj_hist, ratio_val ) ;
                   hp_nj -> SetBinError( bi_nj_hist, ratio_err ) ;
@@ -124,25 +125,17 @@
       h_hdp_160bins -> GetXaxis() -> LabelsOption( "v" ) ;
 
 
+      for ( int nb_count = 0; nb_count < nb_nb; nb_count++)
+      {
+         h_ratio_nb[nb_count] -> GetXaxis() -> LabelsOption( "v" ) ;
+         h_ratio_nb[nb_count] -> SetMarkerStyle(20) ;
+      }
 
-      h_ratio_nb0 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nb0 -> SetMarkerStyle(20) ;
-      h_ratio_nb1 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nb1 -> SetMarkerStyle(20) ;
-      h_ratio_nb2 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nb2 -> SetMarkerStyle(20) ;
-      h_ratio_nb3 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nb3 -> SetMarkerStyle(20) ;
-
-      h_ratio_nj1 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nj1 -> SetMarkerStyle(20) ;
-      h_ratio_nj2 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nj2 -> SetMarkerStyle(20) ;
-      h_ratio_nj3 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nj3 -> SetMarkerStyle(20) ;
-      h_ratio_nj4 -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ratio_nj4 -> SetMarkerStyle(20) ;
-
+      for ( int nj_count = 1; nj_count <= nb_nj; nj_count++)
+      {
+         h_ratio_nj[nj_count] -> GetXaxis() -> LabelsOption( "v" ) ;
+         h_ratio_nj[nj_count] -> SetMarkerStyle(20) ;
+      }
       h_ratio -> Draw() ;
       gPad -> SetGridy(1) ;
 
@@ -151,6 +144,8 @@
    } // draw_qcd_ratio_v3
 
 //===============================================================================
+#ifndef get_hist_
+#define get_hist_
 
    TH1F* get_hist( const char* hname ) {
       TH1F* hp = (TH1F*) gDirectory -> FindObject( hname ) ;
@@ -161,7 +156,7 @@
       }
       return hp ;
    } // get_hist
-
+#endif
 //===============================================================================
 
    void draw_boundaries() {

--- a/draw_qcd_ratio_v3.c
+++ b/draw_qcd_ratio_v3.c
@@ -45,10 +45,10 @@
       TH1F* h_hdp = get_hist( "h_hdp" ) ;
       TH1F* h_max_ldp_weight = get_hist( "h_max_ldp_weight" ) ;
 
-      TH1F* h_ratio = new TH1F( "h_ratio", "QCD H/L ratio", 160, 0.5, 160.5 ) ;
-      TH1F* h_max_ldp_weight_160bins = new TH1F( "h_max_ldp_weight_160bins", "max LDP weight", 160, 0.5, 160.5 ) ;
-      TH1F* h_ldp_160bins = new TH1F( "h_ldp_160bins", "LDP counts, 160 bins", 160, 0.5, 160.5 ) ;
-      TH1F* h_hdp_160bins = new TH1F( "h_hdp_160bins", "HDP counts, 160 bins", 160, 0.5, 160.5 ) ;
+      TH1F* h_ratio = new TH1F( "h_ratio", "QCD H/L ratio", (nb_htmht-3) * nb_nb * nb_nj, 0.5, (nb_htmht-3) * nb_nb * nb_nj + 0.5 ) ;
+      TH1F* h_max_ldp_weight_search_bins = new TH1F( "h_max_ldp_weight_search_bins", "max LDP weight", (nb_htmht-3) * nb_nb * nb_nj, 0.5, (nb_htmht-3) * nb_nb * nb_nj + 0.5 ) ;
+      TH1F* h_ldp_search_bins = new TH1F( "h_ldp_search_bins", "LDP counts, (nb_htmht-3) * nb_nb * nb_nj bins", (nb_htmht-3) * nb_nb * nb_nj, 0.5, (nb_htmht-3) * nb_nb * nb_nj + 0.5 ) ;
+      TH1F* h_hdp_search_bins = new TH1F( "h_hdp_search_bins", "HDP counts, (nb_htmht-3) * nb_nb * nb_nj bins", (nb_htmht-3) * nb_nb * nb_nj, 0.5, (nb_htmht-3) * nb_nb * nb_nj + 0.5 ) ;
 
       TH1F * h_ratio_nb[10], * h_ratio_nj[10];
 
@@ -91,14 +91,14 @@
                   h_ratio -> SetBinContent( bi_search_hist, ratio_val ) ;
                   h_ratio -> SetBinError( bi_search_hist, ratio_err ) ;
                   h_ratio -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
-                  h_max_ldp_weight_160bins -> SetBinContent( bi_search_hist, h_max_ldp_weight->GetBinContent( bi_hist ) ) ;
-                  h_max_ldp_weight_160bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
-                  h_ldp_160bins -> SetBinContent( bi_search_hist, ldp_val ) ;
-                  h_ldp_160bins -> SetBinError( bi_search_hist, ldp_err ) ;
-                  h_ldp_160bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
-                  h_hdp_160bins -> SetBinContent( bi_search_hist, hdp_val ) ;
-                  h_hdp_160bins -> SetBinError( bi_search_hist, hdp_err ) ;
-                  h_hdp_160bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
+                  h_max_ldp_weight_search_bins -> SetBinContent( bi_search_hist, h_max_ldp_weight->GetBinContent( bi_hist ) ) ;
+                  h_max_ldp_weight_search_bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
+                  h_ldp_search_bins -> SetBinContent( bi_search_hist, ldp_val ) ;
+                  h_ldp_search_bins -> SetBinError( bi_search_hist, ldp_err ) ;
+                  h_ldp_search_bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
+                  h_hdp_search_bins -> SetBinContent( bi_search_hist, hdp_val ) ;
+                  h_hdp_search_bins -> SetBinError( bi_search_hist, hdp_err ) ;
+                  h_hdp_search_bins -> GetXaxis() -> SetBinLabel( bi_search_hist, label ) ;
                   printf( "  search %3d : %30s : R= %6.4f +/- %6.4f\n", bi_search_hist, label, ratio_val, ratio_err ) ;
                   TH1F* hp_nb(0x0) ;
                   hp_nb = h_ratio_nb[bi_nb-1] ;
@@ -120,9 +120,9 @@
       h_ratio -> GetXaxis() -> LabelsOption( "v" ) ;
       h_ratio -> SetMarkerStyle(20) ;
 
-      h_max_ldp_weight_160bins -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_ldp_160bins -> GetXaxis() -> LabelsOption( "v" ) ;
-      h_hdp_160bins -> GetXaxis() -> LabelsOption( "v" ) ;
+      h_max_ldp_weight_search_bins -> GetXaxis() -> LabelsOption( "v" ) ;
+      h_ldp_search_bins -> GetXaxis() -> LabelsOption( "v" ) ;
+      h_hdp_search_bins -> GetXaxis() -> LabelsOption( "v" ) ;
 
 
       for ( int nb_count = 0; nb_count < nb_nb; nb_count++)

--- a/fill_data_hists_loop_v2d.c
+++ b/fill_data_hists_loop_v2d.c
@@ -51,15 +51,18 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
 
    TH1F * h_hdp_nb[10], *h_ldp_nb[10];
 
+   TH1::SetDefaultSumw2(); // to make sure all TH1 histograms have Sumw2 enabled
+
+
       for ( int nb = 0; nb < nb_nb; nb++)
       {
 
          TString nb_str         ; nb_str         .Form("%d",nb);
 
-         h_hdp_nb[nb] = new TH1F( "h_hdp_nb"+nb_str, "HDP events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_hdp_nb[nb] -> Sumw2() ;
+         h_hdp_nb[nb] = new TH1F( "h_hdp_nb"+nb_str, "HDP events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
          set_bin_labels( h_hdp_nb[nb] ) ;
 
-         h_ldp_nb[nb] = new TH1F( "h_ldp_nb"+nb_str, "ldp events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_ldp_nb[nb] -> Sumw2() ;
+         h_ldp_nb[nb] = new TH1F( "h_ldp_nb"+nb_str, "ldp events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
          set_bin_labels( h_ldp_nb[nb] ) ;
 
 
@@ -67,26 +70,26 @@ void fill_data_hists_loop_v2d::Loop( bool verb, int nloop )
 
 
 
-   TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ; h_hdp -> Sumw2() ;
+   TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ;
    set_bin_labels_div_by_nb( h_hdp ) ;
-   TH1F* h_nbsum_hdp = new TH1F( "h_nbsum_hdp", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nbsum_hdp -> Sumw2() ;
+   TH1F* h_nbsum_hdp = new TH1F( "h_nbsum_hdp", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_nbsum_hdp ) ;
-   TH1F* h_mhtc_hdp = new TH1F( "h_mhtc_hdp", "HDP events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ; h_mhtc_hdp -> Sumw2() ;
+   TH1F* h_mhtc_hdp = new TH1F( "h_mhtc_hdp", "HDP events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ;
    set_bin_labels_mhtc_plot( h_mhtc_hdp ) ;
 
-   TH1F* h_ldp = new TH1F( "h_ldp", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ; h_ldp -> Sumw2() ;
+   TH1F* h_ldp = new TH1F( "h_ldp", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ;
    set_bin_labels_div_by_nb( h_ldp ) ;
-   TH1F* h_nbsum_ldp = new TH1F( "h_nbsum_ldp", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nbsum_ldp -> Sumw2() ;
+   TH1F* h_nbsum_ldp = new TH1F( "h_nbsum_ldp", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_nbsum_ldp ) ;
-   TH1F* h_mhtc_ldp = new TH1F( "h_mhtc_ldp", "ldp events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ; h_mhtc_ldp -> Sumw2() ;
+   TH1F* h_mhtc_ldp = new TH1F( "h_mhtc_ldp", "ldp events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ;
    set_bin_labels_mhtc_plot( h_mhtc_ldp ) ;
 
-   TH1F* h_mht_all = new TH1F( "h_mht_all", "MHT, all events", 100, 0., 1000. ) ; h_mht_all -> Sumw2() ;
-   TH1F* h_mht_badmu = new TH1F( "h_mht_badmu", "MHT, badmu", 100, 0., 1000. ) ; h_mht_badmu -> Sumw2() ;
-   TH1F* h_mht_allrejected = new TH1F( "h_mht_allrejected", "MHT, all rejected", 100, 0., 1000. ) ; h_mht_allrejected -> Sumw2() ;
-   TH1F* h_met_over_calomet_all = new TH1F( "h_met_over_calomet_all", "MET/CaloMET, all events", 100., 0., 10. ) ; h_met_over_calomet_all -> Sumw2() ;
-   TH1F* h_met_over_calomet_badmu = new TH1F( "h_met_over_calomet_badmu", "MET/CaloMET, badmu", 100., 0., 10. ) ; h_met_over_calomet_badmu -> Sumw2() ;
-   TH1F* h_met_over_calomet_allrejected = new TH1F( "h_met_over_calomet_allrejected", "MET/CaloMET, all rejected", 100., 0., 10. ) ; h_met_over_calomet_badmu -> Sumw2() ;
+   TH1F* h_mht_all = new TH1F( "h_mht_all", "MHT, all events", 100, 0., 1000. ) ;
+   TH1F* h_mht_badmu = new TH1F( "h_mht_badmu", "MHT, badmu", 100, 0., 1000. ) ;
+   TH1F* h_mht_allrejected = new TH1F( "h_mht_allrejected", "MHT, all rejected", 100, 0., 1000. ) ;
+   TH1F* h_met_over_calomet_all = new TH1F( "h_met_over_calomet_all", "MET/CaloMET, all events", 100., 0., 10. ) ;
+   TH1F* h_met_over_calomet_badmu = new TH1F( "h_met_over_calomet_badmu", "MET/CaloMET, badmu", 100., 0., 10. ) ;
+   TH1F* h_met_over_calomet_allrejected = new TH1F( "h_met_over_calomet_allrejected", "MET/CaloMET, all rejected", 100., 0., 10. ) ;
 
    TH1F* h_mdp_all = new TH1F( "h_mdp_all", "Min Delta phi, 4 leading jets", 64, 0., 3.2 ) ;
 

--- a/fill_hists_loop_v2c.c
+++ b/fill_hists_loop_v2c.c
@@ -29,16 +29,13 @@
 #include "histio.c"
 #include <iostream>
 #include <vector>
+#include "lumi_taken.h"
+
 using namespace std ;
 
 
 void fill_hists_loop_v2c::Loop( bool verb, int nloop )
 {
-
-   //double lumi = 2300. ;
-   //double lumi = 815. ;
-   ////////double lumi = 2585. ;
-   double lumi = 7632. ;
 
    bool islostlep(false) ;
    bool ishadtau(false) ;
@@ -203,7 +200,7 @@ void fill_hists_loop_v2c::Loop( bool verb, int nloop )
       set_bi() ;
 
 
-      double hw = Weight * lumi ;
+      double hw = Weight * lumi_ ;
 
       if ( islostlep && hasHadTau ) continue ;
       if ( ishadtau && !hasHadTau ) continue ;

--- a/fill_hists_loop_v2d.c
+++ b/fill_hists_loop_v2d.c
@@ -94,52 +94,54 @@ void fill_hists_loop_v2d::Loop( bool verb, int nloop )
 
    TH1F* h_hdp_nb[10], *h_ldp_nb[10];
 
+   TH1::SetDefaultSumw2(); // to make sure all TH1 histograms have Sumw2 enabled
+
    for ( int nb = 0; nb < nb_nb; nb++)
    {
 
       TString nb_str         ; nb_str         .Form("%d",nb);
-      h_hdp_nb[nb] = new TH1F( "h_hdp_nb"+nb_str, "HDP events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_hdp_nb[nb] -> Sumw2() ;
+      h_hdp_nb[nb] = new TH1F( "h_hdp_nb"+nb_str, "HDP events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
       set_bin_labels( h_hdp_nb[nb] ) ;
 
-      h_ldp_nb[nb] = new TH1F( "h_ldp_nb"+nb_str, "ldp events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_ldp_nb[nb] -> Sumw2() ;
+      h_ldp_nb[nb] = new TH1F( "h_ldp_nb"+nb_str, "ldp events, Nb="+nb_str, nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
       set_bin_labels( h_ldp_nb[nb] ) ;
 
 
    }
 
 
-   TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ; h_hdp -> Sumw2() ;
+   TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ;
    set_bin_labels_div_by_nb( h_hdp ) ;
-   TH1F* h_nbsum_hdp = new TH1F( "h_nbsum_hdp", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nbsum_hdp -> Sumw2() ;
+   TH1F* h_nbsum_hdp = new TH1F( "h_nbsum_hdp", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_nbsum_hdp ) ;
 
-   TH1F* h_mhtc_hdp = new TH1F( "h_mhtc_hdp", "HDP events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ; h_mhtc_hdp -> Sumw2() ;
+   TH1F* h_mhtc_hdp = new TH1F( "h_mhtc_hdp", "HDP events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ;
    set_bin_labels_mhtc_plot( h_mhtc_hdp ) ;
-   TH1F* h_mhtc_nbsum_hdp = new TH1F( "h_mhtc_nbsum_hdp", "HDP events, MHTC, Nbsum", nb_nj*nb_ht[1], 0.5, nb_nj*nb_ht[1]+0.5 ) ; h_mhtc_nbsum_hdp -> Sumw2() ;
+   TH1F* h_mhtc_nbsum_hdp = new TH1F( "h_mhtc_nbsum_hdp", "HDP events, MHTC, Nbsum", nb_nj*nb_ht[1], 0.5, nb_nj*nb_ht[1]+0.5 ) ;
    set_bin_labels_mhtc_nbsum_plot( h_mhtc_nbsum_hdp ) ;
 
-   TH1F* h_ldp = new TH1F( "h_ldp", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ; h_ldp -> Sumw2() ;
+   TH1F* h_ldp = new TH1F( "h_ldp", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ;
    set_bin_labels_div_by_nb( h_ldp ) ;
-   TH1F* h_nbsum_ldp = new TH1F( "h_nbsum_ldp", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ; h_nbsum_ldp -> Sumw2() ;
+   TH1F* h_nbsum_ldp = new TH1F( "h_nbsum_ldp", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_nbsum_ldp ) ;
-   TH1F* h_mhtc_ldp = new TH1F( "h_mhtc_ldp", "ldp events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ; h_mhtc_ldp -> Sumw2() ;
+   TH1F* h_mhtc_ldp = new TH1F( "h_mhtc_ldp", "ldp events, MHTC", nb_nj*nb_nb*nb_ht[1], 0.5, nb_nj*nb_nb*nb_ht[1]+0.5 ) ;
    set_bin_labels_mhtc_plot( h_mhtc_ldp ) ;
-   TH1F* h_mhtc_nbsum_ldp = new TH1F( "h_mhtc_nbsum_ldp", "ldp events, MHTC, Nbsum", nb_nj*nb_ht[1], 0.5, nb_nj*nb_ht[1]+0.5 ) ; h_mhtc_nbsum_ldp -> Sumw2() ;
+   TH1F* h_mhtc_nbsum_ldp = new TH1F( "h_mhtc_nbsum_ldp", "ldp events, MHTC, Nbsum", nb_nj*nb_ht[1], 0.5, nb_nj*nb_ht[1]+0.5 ) ;
    set_bin_labels_mhtc_nbsum_plot( h_mhtc_nbsum_ldp ) ;
 
    TH1F* h_jet_eta_badmu = new TH1F( "h_jet_eta_badmu", "Jet eta, bad muon", 55, -5.5, 5.5 ) ;
 
-   TH1F* h_mht_all = new TH1F( "h_mht_all", "MHT, all events", 100, 0., 1000. ) ; h_mht_all -> Sumw2() ;
-   TH1F* h_mht_badmu = new TH1F( "h_mht_badmu", "MHT, badmu", 100, 0., 1000. ) ; h_mht_badmu -> Sumw2() ;
-   TH1F* h_mht_met100_calomet80_rejected = new TH1F( "h_mht_met100_calomet80_rejected", "MHT, MET<100 or CaloMET<80", 100, 0., 1000. ) ; h_mht_met100_calomet80_rejected -> Sumw2() ;
-   TH1F* h_mht_filters = new TH1F( "h_mht_filters", "MHT, all rejected", 100, 0., 1000. ) ; h_mht_filters -> Sumw2() ;
-   TH1F* h_mht_allrejected = new TH1F( "h_mht_allrejected", "MHT, all rejected", 100, 0., 1000. ) ; h_mht_allrejected -> Sumw2() ;
+   TH1F* h_mht_all = new TH1F( "h_mht_all", "MHT, all events", 100, 0., 1000. ) ;
+   TH1F* h_mht_badmu = new TH1F( "h_mht_badmu", "MHT, badmu", 100, 0., 1000. ) ;
+   TH1F* h_mht_met100_calomet80_rejected = new TH1F( "h_mht_met100_calomet80_rejected", "MHT, MET<100 or CaloMET<80", 100, 0., 1000. ) ;
+   TH1F* h_mht_filters = new TH1F( "h_mht_filters", "MHT, all rejected", 100, 0., 1000. ) ;
+   TH1F* h_mht_allrejected = new TH1F( "h_mht_allrejected", "MHT, all rejected", 100, 0., 1000. ) ;
 
-   TH1F* h_met_over_calomet_all = new TH1F( "h_met_over_calomet_all", "MET/CaloMET, all events", 100., 0., 10. ) ; h_met_over_calomet_all -> Sumw2() ;
-   TH1F* h_met_over_calomet_badmu = new TH1F( "h_met_over_calomet_badmu", "MET/CaloMET, badmu", 100., 0., 10. ) ; h_met_over_calomet_badmu -> Sumw2() ;
-   TH1F* h_met_over_calomet_met100_calomet80_rejected = new TH1F( "h_met_over_calomet_met100_calomet80_rejected", "MET/CaloMET, MET<100 or CaloMET<80", 100., 0., 10. ) ; h_met_over_calomet_met100_calomet80_rejected -> Sumw2() ;
-   TH1F* h_met_over_calomet_filters = new TH1F( "h_met_over_calomet_filters", "MET/CaloMET, all rejected", 100., 0., 10. ) ; h_met_over_calomet_filters -> Sumw2() ;
-   TH1F* h_met_over_calomet_allrejected = new TH1F( "h_met_over_calomet_allrejected", "MET/CaloMET, all rejected", 100., 0., 10. ) ; h_met_over_calomet_allrejected -> Sumw2() ;
+   TH1F* h_met_over_calomet_all = new TH1F( "h_met_over_calomet_all", "MET/CaloMET, all events", 100., 0., 10. ) ;
+   TH1F* h_met_over_calomet_badmu = new TH1F( "h_met_over_calomet_badmu", "MET/CaloMET, badmu", 100., 0., 10. ) ;
+   TH1F* h_met_over_calomet_met100_calomet80_rejected = new TH1F( "h_met_over_calomet_met100_calomet80_rejected", "MET/CaloMET, MET<100 or CaloMET<80", 100., 0., 10. ) ;
+   TH1F* h_met_over_calomet_filters = new TH1F( "h_met_over_calomet_filters", "MET/CaloMET, all rejected", 100., 0., 10. ) ;
+   TH1F* h_met_over_calomet_allrejected = new TH1F( "h_met_over_calomet_allrejected", "MET/CaloMET, all rejected", 100., 0., 10. ) ;
 
    TH1F* h_mdp_all = new TH1F( "h_mdp_all", "Min Delta phi, 4 leading jets", 64, 0., 3.2 ) ;
 

--- a/fill_hists_loop_v2d.c
+++ b/fill_hists_loop_v2d.c
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <vector>
 
+#include "lumi_taken.h"
 #include "binning.h"
 #include "histio.c"
 
@@ -45,11 +46,6 @@ void fill_hists_loop_v2d::Loop( bool verb, int nloop )
    setup_bins() ;
 
 
-   //double lumi = 2300. ;
-   //double lumi = 815. ;
-   ///////double lumi = 2585. ;
-   //////double lumi = 7632. ;
-   double lumi = 12903. ;
 
    bool islostlep(false) ;
    bool ishadtau(false) ;
@@ -219,8 +215,8 @@ void fill_hists_loop_v2d::Loop( bool verb, int nloop )
       set_bi() ;
 
 
-      //////////////double hw = Weight * lumi ;
-      double hw = Weight * puWeight * lumi ; // add pu weight
+      //////////////double hw = Weight * lumi_ ;
+      double hw = Weight * puWeight * lumi_ ; // add pu weight
 
       if ( islostlep && hasHadTau ) continue ;
       if ( ishadtau && !hasHadTau ) continue ;

--- a/gen_modelfit_input1.c
+++ b/gen_modelfit_input1.c
@@ -1,12 +1,22 @@
+#ifndef gen_modelfit_input1_c
+#define gen_modelfit_input1_c
 
+#include "TH1.h"
+#include "TFile.h"
+#include "TLegend.h"
+#include "TPad.h"
+#include "THStack.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include <fstream>
 
+#include "binning.h"
 
    void gen_modelfit_input(
          const char* data_file    = "outputfiles/nbsum-input-data.txt",
          const char* lostlep_file = "outputfiles/nbsum-input-lostlep.txt",
          const char* hadtau_file  = "outputfiles/nbsum-input-hadtau.txt",
          const char* znunu_file   = "outputfiles/nbsum-input-znunu.txt",
-         const char* modelfit_output_file = "outputfiles/modelfit-input-all.txt",
          const char* output_hist_file = "outputfiles/modelfit-input-data.root"
                          ) {
 
@@ -27,36 +37,31 @@
       ifs_znunu.open( znunu_file ) ;
       if ( !ifs_znunu.good() ) { printf("\n\n *** Problem opening znunu file: %s\n\n", znunu_file ) ; return ; }
 
-      int    nobs_ldp[4][5] ;
-      double nonqcd_val_ldp[4][5] ;
-      double nonqcd_err_ldp[4][5] ;
+      int    nobs_ldp[10][10] ;
+      double nonqcd_val_ldp[10][10] ;
+      double nonqcd_err_ldp[10][10] ;
 
-      int    nobs_hdp[4][5] ;
-      double nonqcd_val_hdp[4][5] ;
-      double nonqcd_err_hdp[4][5] ;
+      int    nobs_hdp[10][10] ;
+      double nonqcd_val_hdp[10][10] ;
+      double nonqcd_err_hdp[10][10] ;
 
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
+      TH1F* h_ratio = new TH1F( "h_ratio", "H/L ratio", nBinsHT * nb_nj, 0.5, nBinsHT * nb_n + 0.5 ) ;
 
-      TH1F* h_ratio = new TH1F( "h_ratio", "H/L ratio", 12, 0.5, 12.5 ) ;
-
-      TH1F* h_ldp_lostlep = new TH1F( "h_ldp_lostlep", "ldp, lostlep", 12, 0.5, 12.5 ) ;
-      TH1F* h_ldp_hadtau = new TH1F( "h_ldp_hadtau", "ldp, hadtau", 12, 0.5, 12.5 ) ;
-      TH1F* h_ldp_znunu = new TH1F( "h_ldp_znunu", "ldp, znunu", 12, 0.5, 12.5 ) ;
-      TH1F* h_ldp_data = new TH1F( "h_ldp_data", "ldp, data", 12, 0.5, 12.5 ) ;
+      TH1F* h_ldp_lostlep = new TH1F( "h_ldp_lostlep", "ldp, lostlep", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_ldp_hadtau = new TH1F( "h_ldp_hadtau", "ldp, hadtau", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_ldp_znunu = new TH1F( "h_ldp_znunu", "ldp, znunu", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_ldp_data = new TH1F( "h_ldp_data", "ldp, data", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
 
 
-      TH1F* h_hdp_lostlep = new TH1F( "h_hdp_lostlep", "hdp, lostlep", 12, 0.5, 12.5 ) ;
-      TH1F* h_hdp_hadtau = new TH1F( "h_hdp_hadtau", "hdp, hadtau", 12, 0.5, 12.5 ) ;
-      TH1F* h_hdp_znunu = new TH1F( "h_hdp_znunu", "hdp, znunu", 12, 0.5, 12.5 ) ;
-      TH1F* h_hdp_data = new TH1F( "h_hdp_data", "hdp, data", 12, 0.5, 12.5 ) ;
+      TH1F* h_hdp_lostlep = new TH1F( "h_hdp_lostlep", "hdp, lostlep", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_hdp_hadtau = new TH1F( "h_hdp_hadtau", "hdp, hadtau", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_hdp_znunu = new TH1F( "h_hdp_znunu", "hdp, znunu", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_hdp_data = new TH1F( "h_hdp_data", "hdp, data", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
 
 
       int bi_hist(0) ;
 
-      for ( int bi_ht=1; bi_ht<=nb_ht; bi_ht++ ) {
+      for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
 
                bi_hist ++ ;
@@ -183,7 +188,7 @@
 
                printf("\n") ;
 
-               if ( !(bi_ht==1 && bi_nj>2) ) {
+               if ( !(bi_ht==1 && bi_nj>nb_nj-2) ) {  // skip top two njets bins for lowest HT
                   h_ratio -> SetBinContent( bi_hist, ratio_val ) ;
                   h_ratio -> SetBinError( bi_hist, ratio_err ) ;
                } else {
@@ -337,4 +342,4 @@
 
 
 
-
+#endif

--- a/gen_modelfit_input1.c
+++ b/gen_modelfit_input1.c
@@ -12,7 +12,7 @@
 
 #include "binning.h"
 
-   void gen_modelfit_input(
+   void gen_modelfit_input1(
          const char* data_file    = "outputfiles/nbsum-input-data.txt",
          const char* lostlep_file = "outputfiles/nbsum-input-lostlep.txt",
          const char* hadtau_file  = "outputfiles/nbsum-input-hadtau.txt",
@@ -45,18 +45,18 @@
       double nonqcd_val_hdp[10][10] ;
       double nonqcd_err_hdp[10][10] ;
 
-      TH1F* h_ratio = new TH1F( "h_ratio", "H/L ratio", nBinsHT * nb_nj, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_ratio = new TH1F( "h_ratio", "H/L ratio", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
 
-      TH1F* h_ldp_lostlep = new TH1F( "h_ldp_lostlep", "ldp, lostlep", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
-      TH1F* h_ldp_hadtau = new TH1F( "h_ldp_hadtau", "ldp, hadtau", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
-      TH1F* h_ldp_znunu = new TH1F( "h_ldp_znunu", "ldp, znunu", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
-      TH1F* h_ldp_data = new TH1F( "h_ldp_data", "ldp, data", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_ldp_lostlep = new TH1F( "h_ldp_lostlep", "ldp, lostlep", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
+      TH1F* h_ldp_hadtau = new TH1F( "h_ldp_hadtau", "ldp, hadtau", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
+      TH1F* h_ldp_znunu = new TH1F( "h_ldp_znunu", "ldp, znunu", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
+      TH1F* h_ldp_data = new TH1F( "h_ldp_data", "ldp, data", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
 
 
-      TH1F* h_hdp_lostlep = new TH1F( "h_hdp_lostlep", "hdp, lostlep", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
-      TH1F* h_hdp_hadtau = new TH1F( "h_hdp_hadtau", "hdp, hadtau", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
-      TH1F* h_hdp_znunu = new TH1F( "h_hdp_znunu", "hdp, znunu", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
-      TH1F* h_hdp_data = new TH1F( "h_hdp_data", "hdp, data", nBinsHT * nb_n, 0.5, nBinsHT * nb_n + 0.5 ) ;
+      TH1F* h_hdp_lostlep = new TH1F( "h_hdp_lostlep", "hdp, lostlep", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
+      TH1F* h_hdp_hadtau = new TH1F( "h_hdp_hadtau", "hdp, hadtau", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
+      TH1F* h_hdp_znunu = new TH1F( "h_hdp_znunu", "hdp, znunu", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
+      TH1F* h_hdp_data = new TH1F( "h_hdp_data", "hdp, data", nBinsHT * nb_nj, 0.5, nBinsHT * nb_nj + 0.5 ) ;
 
 
       int bi_hist(0) ;

--- a/get_hist.h
+++ b/get_hist.h
@@ -1,0 +1,22 @@
+#include "TH1.h"
+#include "TFile.h"
+
+#ifndef input_files_h
+#define input_files_h
+
+
+TH1F* get_hist( TFile* tf, const char* hname ) {
+
+   TH1F* hp   = (TH1F*) tf -> Get( hname ) ;
+   if ( hp == 0x0 ) {
+
+      printf("\n\n *** Can't find hist %s.\n\n", hname ) ;
+      gSystem -> Exit(-1) ;
+
+   }
+
+   return hp ;
+
+} // get_hist
+
+#endif

--- a/histio.c
+++ b/histio.c
@@ -40,6 +40,8 @@ void saveHist(const char* filename, const char* pat)
   outf.Close() ;
 
   delete iter ;
+  gDirectory->DeleteAll();//This line will remove histrograms from memory. Without this line, when we create a histogram, I will be saved everytime we call saveHist function. Important when we use "run_all.C"
+
 }
 
 

--- a/lumi_taken.h
+++ b/lumi_taken.h
@@ -1,0 +1,7 @@
+#ifndef lumi_taken_h
+#define lumi_taken_h
+
+   double lumi_ = 12903. ;
+
+
+#endif

--- a/make_data_input_files1.c
+++ b/make_data_input_files1.c
@@ -1,9 +1,17 @@
+#ifndef make_data_input_files1_c
+#define make_data_input_files1_c
 
+#include "TH1.h"
+#include "TDirectory.h"
+#include "TFile.h"
+#include "binning.h"
 
    void make_data_input_files1( const char* input_root_file = "outputfiles/hists-data-v2d.root",
                                  const char* output_text_file = "outputfiles/combine-input-data.txt",
                                  const char* nbsum_text_file = "outputfiles/nbsum-input-data.txt"
                                ) {
+
+      setup_bins(); 
 
       gDirectory -> Delete( "h*" ) ;
 
@@ -34,11 +42,6 @@
       TH1F* h_hdp = (TH1F*) tf -> Get( "h_hdp" ) ;
       if ( h_hdp == 0x0 ) { printf("\n\n *** Missing h_hdp\n\n") ; return ; }
 
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
-
       int bi_hist(0) ;
       int bi_control(0) ;
       int bi_search(0) ;
@@ -56,7 +59,7 @@
 
                TString hist_bin_label( h_ldp -> GetXaxis() -> GetBinLabel( bi_hist ) ) ;
 
-               int bi_ht, bi_mht ;
+               int bi_ht = 0, bi_mht = 0;
 
                if ( bi_htmht == 1 ) { bi_ht = 1; bi_mht = 1; }
                if ( bi_htmht == 2 ) { bi_ht = 2; bi_mht = 1; }
@@ -112,7 +115,7 @@
 
      //--------
 
-      for ( int bi_ht=1; bi_ht<=nb_ht; bi_ht++ ) {
+      for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
 
             float ldp_nbsum_val(0.) ;
@@ -155,4 +158,4 @@
    } // make_data_input_files1
 
 
-
+#endif

--- a/make_hadtau_input_files1.c
+++ b/make_hadtau_input_files1.c
@@ -1,10 +1,19 @@
+#ifndef make_hadtau_input_files1_c
+#define make_hadtau_input_files1_c
 
-   TH1* get_hist( TFile* tf, const char* hname ) ;
+#include "TFile.h"
+#include "TH1.h"
+#include "TString.h"
+#include "TSystem.h"
+#include "binning.h"
+#include "get_hist.h"
 
    void make_hadtau_input_files1( const char* input_root_file  = "non-qcd-inputs-topup2/ARElog60_12.9ifb_HadTauEstimation_data_formatted_New.root",
                                   const char* output_text_file = "outputfiles/combine-input-hadtau.txt",
                                   const char* nbsum_text_file  = "outputfiles/nbsum-input-hadtau.txt"
                                ) {
+
+      setup_bins();
 
       gDirectory -> Delete( "h*" ) ;
 
@@ -145,10 +154,6 @@
 
 
 
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
 
       int bi_hist(0) ;
       int bi_control(0) ;
@@ -186,7 +191,7 @@
 
                TString hist_bin_label( h_pred_lowdphi -> GetXaxis() -> GetBinLabel( bi_hist ) ) ;
 
-               int bi_ht, bi_mht ;
+               int bi_ht = 0, bi_mht = 0;
 
                if ( bi_htmht == 1 ) { bi_ht = 1; bi_mht = 1; }
                if ( bi_htmht == 2 ) { bi_ht = 2; bi_mht = 1; }
@@ -270,7 +275,7 @@
 
      //-----
 
-      for ( int bi_ht=1; bi_ht<=nb_ht; bi_ht++ ) {
+      for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
 
             float ldp_nbsum_val(0.) ;
@@ -378,19 +383,5 @@
 
 
 
-  //========================================================================================================
 
-   TH1* get_hist( TFile* tf, const char* hname ) {
-      TH1* hp   = (TH1*) tf -> Get( hname ) ;
-      if ( hp == 0x0 ) {
-         printf("\n\n *** Can't find hist %s.\n\n", hname ) ;
-         gSystem -> Exit(-1) ;
-      }
-      return hp ;
-   } // get_hist
-
-  //========================================================================================================
-
-
-
-
+#endif

--- a/make_hadtau_input_files1.c
+++ b/make_hadtau_input_files1.c
@@ -158,10 +158,11 @@
       int bi_hist(0) ;
       int bi_control(0) ;
       int bi_search(0) ;
-      for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
+      for ( int bi_nj=2; bi_nj<=nb_nj; bi_nj++ ) {
          for ( int bi_nb=1; bi_nb<=nb_nb; bi_nb++ ) {
             for ( int bi_htmht=1; bi_htmht<=nb_htmht; bi_htmht++ ) {
 
+               if ( bin_edges_nj[bi_nj-1] < 2.5 ) continue;// because lost lepton input file lasks NJets = 2 bin
                bi_hist ++ ;
 
                double ldp_val = h_pred_lowdphi -> GetBinContent( bi_hist ) ;
@@ -276,7 +277,9 @@
      //-----
 
       for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
-         for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
+         for ( int bi_nj=2; bi_nj<=nb_nj; bi_nj++ ) {
+
+            if ( bin_edges_nj[bi_nj-1] < 2.5 ) continue; // because znuznu input file lasks NJets = 2 bin
 
             float ldp_nbsum_val(0.) ;
             float hdp_nbsum_val(0.) ;

--- a/make_lostlep_input_files1.c
+++ b/make_lostlep_input_files1.c
@@ -1,5 +1,13 @@
+#ifndef make_lostlep_input_files1_c 
+#define make_lostlep_input_files1_c
 
-   TH1* get_hist( TFile* tf, const char* hname ) ;
+#include "TH1.h"
+#include "TString.h"
+#include "TFile.h"
+#include "TSystem.h"
+#include "binning.h"
+#include "get_hist.h"
+
 
    void make_lostlep_input_files1(
                                  const char* ldp_input_root_file = "non-qcd-inputs-topup2/LLPrediction_QCD_LDP_Jul26_newSF.root",
@@ -7,6 +15,8 @@
                                  const char* output_text_file = "outputfiles/combine-input-lostlep.txt",
                                  const char* nbsum_text_file = "outputfiles/nbsum-input-lostlep.txt"
                                ) {
+
+      setup_bins();
 
       bool verb(false) ;
 
@@ -222,11 +232,6 @@
 
 
 
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
-
       int bi_hist(0) ;
       int bi_control(0) ;
       int bi_search(0) ;
@@ -286,7 +291,7 @@
 
                TString hist_bin_label( h_ldp -> GetXaxis() -> GetBinLabel( bi_hist ) ) ;
 
-               int bi_ht, bi_mht ;
+               int bi_ht = 0, bi_mht = 0;
 
                if ( bi_htmht == 1 ) { bi_ht = 1; bi_mht = 1; }
                if ( bi_htmht == 2 ) { bi_ht = 2; bi_mht = 1; }
@@ -372,7 +377,7 @@
 
      //---------
 
-      for ( int bi_ht=1; bi_ht<=nb_ht; bi_ht++ ) {
+      for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
 
             float nbsum_lowdphi_val(0.) ;
@@ -484,18 +489,5 @@
 
    } // make_lostlep_input_files1
 
-  //========================================================================================================
 
-   TH1* get_hist( TFile* tf, const char* hname ) {
-      TH1* hp   = (TH1*) tf -> Get( hname ) ;
-      if ( hp == 0x0 ) {
-         printf("\n\n *** Can't find hist %s.\n\n", hname ) ;
-         gSystem -> Exit(-1) ;
-      }
-      return hp ;
-   } // get_hist
-
-  //========================================================================================================
-
-
-
+#endif

--- a/make_lostlep_input_files1.c
+++ b/make_lostlep_input_files1.c
@@ -239,7 +239,8 @@
          for ( int bi_nb=1; bi_nb<=nb_nb; bi_nb++ ) {
             for ( int bi_htmht=1; bi_htmht<=nb_htmht; bi_htmht++ ) {
 
-               bi_hist ++ ;
+               if ( bin_edges_nj[bi_nj-1] < 2.5 ) continue;// because lost lepton input file lasks NJets = 2 bin
+                  bi_hist ++ ;
 
                double ldp_val = h_ldp -> GetBinContent( bi_hist ) ;
                double ldp_hist_err = h_ldp -> GetBinError( bi_hist ) ;
@@ -379,6 +380,9 @@
 
       for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
+
+            if ( bin_edges_nj[bi_nj-1] < 2.5 ) continue; // because znuznu input file lasks NJets = 2 bin
+
 
             float nbsum_lowdphi_val(0.) ;
             float nbsum_lowdphi_err2(0.) ;

--- a/make_znunu_input_files1.c
+++ b/make_znunu_input_files1.c
@@ -170,7 +170,7 @@
 
                TString hist_bin_label( h_ldp -> GetXaxis() -> GetBinLabel( bi_hist ) ) ;
 
-               int bi_ht, bi_mht ;
+               int bi_ht = 0, bi_mht = 0;
 
                if ( bi_htmht == 1 ) { bi_ht = 1; bi_mht = 1; }
                if ( bi_htmht == 2 ) { bi_ht = 2; bi_mht = 1; }

--- a/make_znunu_input_files1.c
+++ b/make_znunu_input_files1.c
@@ -130,7 +130,8 @@
          for ( int bi_nb=1; bi_nb<=nb_nb; bi_nb++ ) {
             for ( int bi_htmht=1; bi_htmht<=nb_htmht; bi_htmht++ ) {
 
-               bi_hist ++ ;
+               if ( bin_edges_nj[bi_nj-1] < 2.5 ) continue; // because znuznu input file lasks NJets = 2 bin
+                  bi_hist ++ ;
 
                double ldp_val = h_ldp -> GetBinContent( bi_hist ) ;
                double ldp_hist_err = h_ldp -> GetBinError( bi_hist ) ;
@@ -259,6 +260,8 @@
 
       for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
+
+            if ( bin_edges_nj[bi_nj-1] < 2.5 ) continue; // because znuznu input file lasks NJets = 2 bin
 
             float nbsum_lowdphi_val(0.) ;
             float nbsum_lowdphi_err2(0.) ;

--- a/make_znunu_input_files1.c
+++ b/make_znunu_input_files1.c
@@ -1,11 +1,19 @@
+#ifndef make_znunu_input_files1_c
+#define make_znunu_input_files1_c
 
-   TH1F* get_hist( TFile* tf, const char* hname ) ;
+#include "TH1.h"
+#include "TFile.h"
+#include "TString.h"
+#include "get_hist.h"
+#include "binning.h"
 
    void make_znunu_input_files1( const char* ldp_input_root_file = "non-qcd-inputs-topup2/ZinvHistos_ldp.root",
                                  const char* hdp_input_root_file = "non-qcd-inputs-topup2/ZinvHistos_hdp.root",
                                  const char* output_text_file = "outputfiles/combine-input-znunu.txt",
                                  const char* nbsum_text_file  = "outputfiles/nbsum-input-znunu.txt"
                                ) {
+      setup_bins();
+
 
       gDirectory -> Delete( "h*" ) ;
 
@@ -114,10 +122,6 @@
 
 
 
-      int nb_nj(4) ;
-      int nb_nb(4) ;
-      int nb_htmht(13) ;
-      int nb_ht(3) ;
 
       int bi_hist(0) ;
       int bi_control(0) ;
@@ -253,7 +257,7 @@
 
      //-----
 
-      for ( int bi_ht=1; bi_ht<=nb_ht; bi_ht++ ) {
+      for ( int bi_ht=1; bi_ht<=nBinsHT; bi_ht++ ) {
          for ( int bi_nj=1; bi_nj<=nb_nj; bi_nj++ ) {
 
             float nbsum_lowdphi_val(0.) ;
@@ -352,18 +356,4 @@
 
    } // make_znunu_input_files1
 
-
-  //========================================================================================================
-
-   TH1F* get_hist( TFile* tf, const char* hname ) {
-      TH1F* hp   = (TH1F*) tf -> Get( hname ) ;
-      if ( hp == 0x0 ) {
-         printf("\n\n *** Can't find hist %s.\n\n", hname ) ;
-         gSystem -> Exit(-1) ;
-      }
-      return hp ;
-   } // get_hist
-
-  //========================================================================================================
-
-
+#endif

--- a/modelfit3.c
+++ b/modelfit3.c
@@ -38,9 +38,6 @@
 
    bool only_fit_mht1 ;
 
-   int njet_bin_to_fix = 1;
-   //int njet_bin_to_fix = 0;
-
    double calc_fit_error( TMinuit* tm, int hbi, int nji, double& simple_model_err ) ;
    void  draw_boundaries( float hmin, float hmax ) ;
 
@@ -66,7 +63,7 @@
          parind ++ ;
       } // hbi.
       for ( int nji=0; nji<nb_nj; nji++ ) {
-         if ( nji == njet_bin_to_fix ) {
+         if ( nji == njet_bin_to_fix_in_qcd_model_fit ) {
             fit_SFqcd_njet[nji] = 1.0 ;
          } else {
             fit_SFqcd_njet[nji] = par[parind] ;
@@ -178,7 +175,7 @@
          parind++ ;
       } // hbi.
       for ( int nji=0; nji<nb_nj; nji++ ) {
-         if (nji == njet_bin_to_fix ) continue;
+         if (nji == njet_bin_to_fix_in_qcd_model_fit ) continue;
          char pname[1000] ;
          sprintf( pname, "SFqcd_njet%d", nji+1 ) ;
          myMinuit->mnparm( parind, pname, 1.0, 0.10, 0., 90., ierflg ) ;
@@ -279,7 +276,7 @@
 
 
       for ( int nji=0; nji<nb_nj; nji++ ) {
-         if ( nji == njet_bin_to_fix ) continue;
+         if ( nji == njet_bin_to_fix_in_qcd_model_fit ) continue;
          char pname[1000] ;
          double val, err ;
          sprintf( pname, "Sqcd_njet%d", nji+1 ) ;

--- a/modelfit3.c
+++ b/modelfit3.c
@@ -269,24 +269,33 @@
          double rel_err(0.) ;
          if ( val != 0 ) { rel_err = err/val ; }
          printf(" %11s  %8.5f +/- %8.5f  (%5.2f)\n", pname, val, err, rel_err ) ;
-         fprintf( ofp, " %11s  %8.5f +/- %8.5f  (%5.2f)\n", pname, val, err, rel_err ) ;
+         fprintf( ofp, " %12s  %8.5f +/- %8.5f  (%5.2f)\n", pname, val, err, rel_err ) ;
          fit_Rqcd_HT[hbi] = val ;
          parind++ ;
       } // hbi.
 
 
       for ( int nji=0; nji<nb_nj; nji++ ) {
-         if ( nji == njet_bin_to_fix_in_qcd_model_fit ) continue;
          char pname[1000] ;
          double val, err ;
          sprintf( pname, "Sqcd_njet%d", nji+1 ) ;
-         myMinuit->GetParameter( parind, val, err ) ;
          double rel_err(0.) ;
+
+         if ( nji == njet_bin_to_fix_in_qcd_model_fit ) 
+         {
+            val = 1; err = 0; rel_err = 0; 
+            printf(" %11s  %6.3f +/- %5.3f  (%5.2f)\n", pname, val, err, rel_err ) ;
+            fprintf( ofp, " %12s  %8.5f +/- %8.5f  (%5.2f)\n", pname, val, err, rel_err ) ;
+         }
+         else
+         {
+         myMinuit->GetParameter( parind, val, err ) ;
          if ( val != 0 ) { rel_err = err/val ; }
          printf(" %11s  %6.3f +/- %5.3f  (%5.2f)\n", pname, val, err, rel_err ) ;
-         fprintf( ofp, " %11s  %6.3f +/- %5.3f  (%5.2f)\n", pname, val, err, rel_err ) ;
+         fprintf( ofp, " %12s  %8.5f +/- %8.5f  (%5.2f)\n", pname, val, err, rel_err ) ;
          fit_SFqcd_njet[nji] = val ;
          parind++ ;
+         }
       } // nji.
       printf("\n\n") ;
 

--- a/run_all.C
+++ b/run_all.C
@@ -13,7 +13,9 @@
 #include "make_lostlep_input_files1.c"
 #include "make_hadtau_input_files1.c"
 #include "make_znunu_input_files1.c"
+#include "syst_2015_v2.c"
 
+#include "draw_badjet_cat_v3.c"
 
 void run_all ( TString skim_slim_input_dir = "" )
 
@@ -53,4 +55,8 @@ void run_all ( TString skim_slim_input_dir = "" )
    make_hadtau_input_files1();
    make_znunu_input_files1();
 
+   syst_2015_v2 f3;
+   f3.Loop();
+
+   draw_badjet_cat_v3();
 }

--- a/run_all.C
+++ b/run_all.C
@@ -14,7 +14,7 @@
 #include "make_hadtau_input_files1.c"
 #include "make_znunu_input_files1.c"
 #include "syst_2015_v2.c"
-
+#include "draw_qcd_ratio_v3.c"
 #include "draw_badjet_cat_v3.c"
 
 void run_all ( TString skim_slim_input_dir = "" )
@@ -55,8 +55,9 @@ void run_all ( TString skim_slim_input_dir = "" )
    make_hadtau_input_files1();
    make_znunu_input_files1();
 
+   draw_qcd_ratio_v3();
    syst_2015_v2 f3;
    f3.Loop();
-
    draw_badjet_cat_v3();
+
 }

--- a/run_all.C
+++ b/run_all.C
@@ -16,6 +16,9 @@
 #include "syst_2015_v2.c"
 #include "draw_qcd_ratio_v3.c"
 #include "draw_badjet_cat_v3.c"
+#include "gen_modelfit_input1.c"
+#include "run_modelfit3_on_data.c"
+#include "create_model_ratio_hist1.c"
 
 void run_all ( TString skim_slim_input_dir = "" )
 
@@ -55,9 +58,11 @@ void run_all ( TString skim_slim_input_dir = "" )
    make_hadtau_input_files1();
    make_znunu_input_files1();
 
-   draw_qcd_ratio_v3();
+   gen_modelfit_input1();
+   run_modelfit3_on_data();
    syst_2015_v2 f3;
    f3.Loop();
+   draw_qcd_ratio_v3();
    draw_badjet_cat_v3();
-
+   create_model_ratio_hist1();
 }

--- a/run_all.C
+++ b/run_all.C
@@ -9,6 +9,11 @@
 #include "TFile.h"
 #include "TROOT.h"
 #include "modelfit3.c"
+#include "make_data_input_files1.c"
+#include "make_lostlep_input_files1.c"
+#include "make_hadtau_input_files1.c"
+#include "make_znunu_input_files1.c"
+
 
 void run_all ( TString skim_slim_input_dir = "" )
 
@@ -42,4 +47,10 @@ void run_all ( TString skim_slim_input_dir = "" )
 
    make_qcdmc_input_files1();
    modelfit3();
+
+   make_data_input_files1();
+   make_lostlep_input_files1();
+   make_hadtau_input_files1();
+   make_znunu_input_files1();
+
 }

--- a/slim-code/doSkimSlim.c
+++ b/slim-code/doSkimSlim.c
@@ -302,7 +302,7 @@ using std::vector ;
 
          if ( doSkim ) {
 
-            if ( NJets < 2 ) continue ;  //** changed from 2 to 3
+            if ( NJets < 2 ) continue ;  //** changed from 3 to 2
             if ( MHT < 200. ) continue ; //*** changed from 250 to 200.
             if ( HT < 300. ) continue ;
 

--- a/syst_2015_v2.c
+++ b/syst_2015_v2.c
@@ -7,12 +7,11 @@
 #include "TStopwatch.h"
 #include "TSystem.h"
 
+#include "lumi_taken.h"
 #include "histio.c"
 #include "binning.h"
 
 double calc_dphi( double phi1, double phi2 ) ;
-
-   double lumi_ = 12903. ;
 
 
 void syst_2015_v2::Loop( int max_dump, bool verb )
@@ -22,6 +21,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
    TH1::SetDefaultSumw2(); // to make sure all TH1 histograms have Sumw2 enabled
 
+   setup_bins();
 
    printf("\n\n") ;
 
@@ -54,22 +54,22 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
    for ( int mht_count = 0; mht_count < nb_mht; mht_count++)
    {
 
-   TString mht_str; 
-   if ( mht_count == 0 ) mht_str = "C";
-   else                  mht_str.Form("%d",mht_count);
+   TString mht_str_capital, mht_str; 
+   if ( mht_count == 0 ) {mht_str_capital = "C"; mht_str = "c";}
+   else                  {mht_str_capital.Form("%d",mht_count);mht_str = mht_str_capital;}
 
-   h_mdp_mht                        [mht_count]  = new TH1F( "h_mdp_mht"+mht_str, "Min Delta Phi, MHT"+mht_str, 68, 0., 3.4 ) ;
+   h_mdp_mht                        [mht_count]  = new TH1F( "h_mdp_mht"+mht_str, "Min Delta Phi, MHT"+mht_str_capital, 68, 0., 3.4 ) ;
 
-   h_mdp_badj_in_dphi_mht           [mht_count] = new TH1F( "h_mdp_badj_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str+", bad jet in Dphi", 68, 0., 3.4 ) ;
+   h_mdp_badj_in_dphi_mht           [mht_count] = new TH1F( "h_mdp_badj_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str_capital+", bad jet in Dphi", 68, 0., 3.4 ) ;
 
-   h_mdp_badj_not_in_dphi_mht       [mht_count] = new TH1F( "h_mdp_badj_not_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str+", bad jet not in Dphi", 68, 0., 3.4  );
+   h_mdp_badj_not_in_dphi_mht       [mht_count] = new TH1F( "h_mdp_badj_not_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str_capital+", bad jet not in Dphi", 68, 0., 3.4  );
 
 
-   h_dphiregion_mht                 [mht_count] = new TH1F( "h_dphiregion_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str, 2, -0.5, 1.5 ) ;
+   h_dphiregion_mht                 [mht_count] = new TH1F( "h_dphiregion_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str_capital, 2, -0.5, 1.5 ) ;
 
-   h_dphiregion_badj_in_dphi_mht    [mht_count] = new TH1F( "h_dphiregion_badj_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str+", bad jet in Dphi", 2, -0.5, 1.5 ) ;
+   h_dphiregion_badj_in_dphi_mht    [mht_count] = new TH1F( "h_dphiregion_badj_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str_capital+", bad jet in Dphi", 2, -0.5, 1.5 ) ;
 
-   h_dphiregion_badj_not_in_dphi_mht[mht_count] = new TH1F( "h_dphiregion_badj_not_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str+", bad jet not in Dphi", 2, -0.5, 1.5 ) ;
+   h_dphiregion_badj_not_in_dphi_mht[mht_count] = new TH1F( "h_dphiregion_badj_not_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str_capital+", bad jet not in Dphi", 2, -0.5, 1.5 ) ;
 
    }//mht_count
 
@@ -115,24 +115,25 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
    h_dphiregion_ht_badj_not_in_dphi_all[ht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_badj_not_in_dphi_all", "Dphi region (0=LDP, 1=HDP), bad jet not in Dphi, "+ht_str_long, 2, -0.5, 1.5 ) ;
 
-   for ( int mht_count = 0; mht_count <= nb_mht; mht_count++)
+   for ( int mht_count = 0; mht_count < nb_mht; mht_count++)
    {
-   TString mht_str; 
-   if ( mht_count == 0 ) mht_str = "C"; 
-   else                  mht_str.Form("%d",mht_count);
+
+   TString mht_str_capital, mht_str; 
+   if ( mht_count == 0 ) {mht_str_capital = "C"; mht_str = "c";}
+   else                  {mht_str_capital.Form("%d",mht_count);mht_str = mht_str_capital;}
 
 
-   h_mdp_ht_mht[ht_count][mht_count] = new TH1F( "h_mdp_ht"+ht_str_short+"_mht"+mht_str, "Min Delta Phi, MHT"+mht_str+", "+ht_str_long, 68, 0., 3.4 ) ;
+   h_mdp_ht_mht[ht_count][mht_count] = new TH1F( "h_mdp_ht"+ht_str_short+"_mht"+mht_str, "Min Delta Phi, MHT"+mht_str_capital+", "+ht_str_long, 68, 0., 3.4 ) ; 
+   std::cout << "h_mdp_ht"+ht_str_short+"_mht"+mht_str << std::endl;
+   h_mdp_ht_badj_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_mdp_ht"+ht_str_short+"_badj_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str_capital+", bad jet in Dphi, "+ht_str_long, 68, 0., 3.4 ) ;
 
-   h_mdp_ht_badj_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_mdp_ht"+ht_str_short+"_badj_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str+", bad jet in Dphi, "+ht_str_long, 68, 0., 3.4 ) ;
+   h_mdp_ht_badj_not_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_mdp_ht"+ht_str_short+"_badj_not_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str_capital+", bad jet not in Dphi, "+ht_str_long, 68, 0., 3.4 ) ;
 
-   h_mdp_ht_badj_not_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_mdp_ht"+ht_str_short+"_badj_not_in_dphi_mht"+mht_str, "Min Delta Phi, MHT"+mht_str+", bad jet not in Dphi, "+ht_str_long, 68, 0., 3.4 ) ;
+   h_dphiregion_ht_mht[ht_count][mht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str_capital+", "+ht_str_long, 2, -0.5, 1.5 ) ;
 
-   h_dphiregion_ht_mht[ht_count][mht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str+", "+ht_str_long, 2, -0.5, 1.5 ) ;
+   h_dphiregion_ht_badj_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_badj_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str_capital+", bad jet in Dphi, "+ht_str_long, 2, -0.5, 1.5 ) ;
 
-   h_dphiregion_ht_badj_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_badj_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str+", bad jet in Dphi, "+ht_str_long, 2, -0.5, 1.5 ) ;
-
-   h_dphiregion_ht_badj_not_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_badj_not_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str+", bad jet not in Dphi, "+ht_str_long, 2, -0.5, 1.5 ) ;
+   h_dphiregion_ht_badj_not_in_dphi_mht[ht_count][mht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_badj_not_in_dphi_mht"+mht_str, "Dphi region (0=LDP, 1=HDP), MHT"+mht_str_capital+", bad jet not in Dphi, "+ht_str_long, 2, -0.5, 1.5 ) ;
 
    }//mht_count
    }//ht_count
@@ -215,6 +216,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
       if ( NJets < bin_edges_nj[0] ) continue ;
       if ( MHT < bin_edges_mht[0] ) continue ;
       if ( HT < bin_edges_ht[1][0] ) continue ;
+
 
 
      //-- take out the trash
@@ -515,7 +517,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
       if ( (bi_mht<=3 && bi_ht == 2) || (bi_mht>3 && bi_ht == 1) ) ht_level = 1 ; //medium ht bin
 
-      if ( (bi_mht<=3 && bi_ht == 1) ) ht_level = 1; // low ht bin
+      if ( (bi_mht<=3 && bi_ht == 1) ) ht_level = 0; // low ht bin
 
 
       if ( bi_global < 1 ) continue ; //--- only keep events in search or QCD control.

--- a/syst_2015_v2.c
+++ b/syst_2015_v2.c
@@ -1,3 +1,4 @@
+#ifndef syst_2015_v2_cxx
 #define syst_2015_v2_cxx
 #include "syst_2015_v2.h"
 #include <TH2.h>
@@ -11,10 +12,11 @@
 
 double calc_dphi( double phi1, double phi2 ) ;
 
+   double lumi_ = 12903. ;
+
+
 void syst_2015_v2::Loop( int max_dump, bool verb )
 {
-   /////double lumi = 2300 ;
-   double lumi = 12903. ;
 
    setup_bins() ;
 
@@ -49,7 +51,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
    TH1F* h_dphiregion_badj_not_in_dphi_all = new TH1F( "h_dphiregion_badj_not_in_dphi_all", "Dphi region (0=LDP, 1=HDP), bad jet not in Dphi", 2, -0.5, 1.5 ) ;
    TH1F* h_dphiregion_badj_not_in_dphi_mht[10];
 
-   for ( int mht_count = 0; mht_count <= 4; mht_count++)
+   for ( int mht_count = 0; mht_count < nb_mht; mht_count++)
    {
 
    TString mht_str; 
@@ -113,7 +115,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
    h_dphiregion_ht_badj_not_in_dphi_all[ht_count] = new TH1F( "h_dphiregion_ht"+ht_str_short+"_badj_not_in_dphi_all", "Dphi region (0=LDP, 1=HDP), bad jet not in Dphi, "+ht_str_long, 2, -0.5, 1.5 ) ;
 
-   for ( int mht_count = 0; mht_count <= 4; mht_count++)
+   for ( int mht_count = 0; mht_count <= nb_mht; mht_count++)
    {
    TString mht_str; 
    if ( mht_count == 0 ) mht_str = "C"; 
@@ -147,7 +149,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
    TH1F* h_hdp_nb[10], *h_ldp_nb[10];
 
-   for ( int nb_count = 0; nb_count <= 3; nb_count++)
+   for ( int nb_count = 0; nb_count < nb_nb; nb_count++)
    {
 
    TString nb_str; nb_str.Form("%d",nb_count);
@@ -206,13 +208,13 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
       if (ientry < 0) break;
       nb = fChain->GetEntry(jentry);   nbytes += nb;
 
-      double hw = Weight * lumi ;
+      double hw = Weight * lumi_ ;
 
 
      //--- apply new baseline.
-      if ( NJets < 3 ) continue ;
-      if ( MHT < 250. ) continue ;
-      if ( HT < 300. ) continue ;
+      if ( NJets < bin_edges_nj[0] ) continue ;
+      if ( MHT < bin_edges_mht[0] ) continue ;
+      if ( HT < bin_edges_ht[1][0] ) continue ;
 
 
      //-- take out the trash
@@ -583,13 +585,11 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
       if ( !recalc_in_ldp ) {
          h_hdp -> Fill( bi_global, hw ) ;
          h_hdp_nbsum -> Fill( bi_nbsum_global, hw ) ;
-         if ( BTags < 3  ) h_hdp_nb[BTags] -> Fill( bi_nbsum_global, hw ) ;
-         if ( BTags >= 3 ) h_hdp_nb[3] -> Fill( bi_nbsum_global, hw ) ;
+         h_hdp_nb[bi_nb-1] -> Fill( bi_nbsum_global, hw ) ;
       } else {
          h_ldp -> Fill( bi_global, hw ) ;
          h_ldp_nbsum -> Fill( bi_nbsum_global, hw ) ;
-         if ( BTags < 3  ) h_ldp_nb[BTags] -> Fill( bi_nbsum_global, hw ) ;
-         if ( BTags >= 3 ) h_ldp_nb[3] -> Fill( bi_nbsum_global, hw ) ;
+         h_ldp_nb[bi_nb-1] -> Fill( bi_nbsum_global, hw ) ;
       }
 
 
@@ -797,4 +797,4 @@ double syst_2015_v2::dr_match_rec_to_genjet( int rji, int& match_gji ) {
 
 
 
-
+#endif

--- a/syst_2015_v2.c
+++ b/syst_2015_v2.c
@@ -139,11 +139,11 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
   //-------
 
-   TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ;
+   TH1F* h_hdp = new TH1F( "h_hdp_", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ;
    TH1F* h_hdp_nbsum = new TH1F( "h_hdp_nbsum", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_hdp_nbsum ) ;
 
-   TH1F* h_ldp = new TH1F( "h_ldp", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ;
+   TH1F* h_ldp = new TH1F( "h_ldp_", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ;
    TH1F* h_ldp_nbsum = new TH1F( "h_ldp_nbsum", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_ldp_nbsum ) ;
 

--- a/syst_2015_v2.c
+++ b/syst_2015_v2.c
@@ -140,11 +140,11 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
 
   //-------
 
-   TH1F* h_hdp = new TH1F( "h_hdp_", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ;
+   TH1F* h_hdp = new TH1F( "h_hdp", "HDP events", nb_global, 0.5, nb_global + 0.5 ) ;
    TH1F* h_hdp_nbsum = new TH1F( "h_hdp_nbsum", "HDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_hdp_nbsum ) ;
 
-   TH1F* h_ldp = new TH1F( "h_ldp_", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ;
+   TH1F* h_ldp = new TH1F( "h_ldp", "ldp events", nb_global, 0.5, nb_global + 0.5 ) ;
    TH1F* h_ldp_nbsum = new TH1F( "h_ldp_nbsum", "LDP events", nb_global/nb_nb, 0.5, nb_global/nb_nb + 0.5 ) ;
    set_bin_labels( h_ldp_nbsum ) ;
 
@@ -171,7 +171,7 @@ void syst_2015_v2::Loop( int max_dump, bool verb )
    if (fChain == 0) return;
 
    Long64_t nentries = fChain->GetEntries();
-
+   std::cout << "nentries: " << nentries << std::endl;
    Long64_t n_dump = 0 ;
 
    TStopwatch sw ;

--- a/syst_2015_v2.h
+++ b/syst_2015_v2.h
@@ -22,28 +22,6 @@
 class syst_2015_v2 {
 public :
 
-   //----------
-   float bin_edges_nj[100]  ;
-   float bin_edges_nb[100]  ;
-   float bin_edges_mht[100]  ;
-   float bin_edges_ht[100][100]  ;
-   int   nb_nj ;
-   int   nb_nb ;
-   int   nb_ht[100] ;
-   int   nb_mht ;
- //int   bi_nj ;
- //int   bi_nb ;
- //int   bi_ht ;
- //int   bi_mht ;
-
-   int   nb_htmht ;
- //int   bi_htmht ;
-
-   int   nb_global ;
- //int   bi_global ;
- //int   bi_nbsum_global ;
-
-   void setup_bins() ;
    void set_bi( int nj, int nb, double ht, double mht,
                              int& bi_nj, int& bi_nb, int& bi_ht, int& bi_mht,
                              int& bi_htmht,


### PR DESCRIPTION
Main changes since last pull request:
1- in chi2 model fit, NJet bin that is fixed to one is always bin with NJets = {3,4}
2- I added a new file "lumi_taken.h" that contains the luminosity. So if the lumi changes, we only need to change it once in our code.
3- I added one line to "histio.h" to delete histograms from memory after they are saved. 
4- File "draw_badjet_cat_v3.c" is revised in such a way that we only need to run in once (with no argument) instead of running it three times with "hth", "htm" and "htl" arguments. We used to do:
         .L draw_badjet_cat_v3.c
         draw_badjet_cat_v3("hth")
         draw_badjet_cat_v3("htm")
         draw_badjet_cat_v3("html")
But now, we can do:
         .x draw_badjet_cat_v3.c

5- File "draw_badjet_cat_v3.c" automatically produces "model-pars-qcdmc3.txt". No need to do it by hand anymore.
    5.1- if a parameter fit is zero, "draw_badjet_cat_v3.c" will automatically set it to the value of the previous parameter and with relative error = 1. 
   For example, when I run the code, I see:
               Sqcd_mht1_htl    0.71      0         0.77
               Sqcd_mht2_htl    0.00      0        0.00
  But now, "draw_badjet_cat_v3.c" will automatically change it to:
               Sqcd_mht1_htl    0.71      0         0.77
               Sqcd_mht2_htl   0.70      0         1.00
  with this warning:
        "Warning: I automatically set Sqcd_mht2_htl = Sqcd_mht1_htl and relative error = 1, because  
          Sqcd_mht2_htl was equal to zero"
